### PR TITLE
feat: add merge request note tool

### DIFF
--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -173,6 +173,18 @@ func (n *NotesServiceWrapper) CreateIssueNote(
 	return note, resp, nil
 }
 
+func (n *NotesServiceWrapper) CreateMergeRequestNote(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.CreateMergeRequestNoteOptions,
+) (*gitlab.Note, *gitlab.Response, error) {
+	note, resp, err := n.service.CreateMergeRequestNote(pid, mergeRequest, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return note, resp, nil
+}
+
 // MergeRequestsServiceWrapper wraps the real MergeRequests service.
 type MergeRequestsServiceWrapper struct {
 	service gitlab.MergeRequestsServiceInterface

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -35,6 +35,11 @@ type NotesService interface {
 		issue int64,
 		opt *gitlab.CreateIssueNoteOptions,
 	) (*gitlab.Note, *gitlab.Response, error)
+	CreateMergeRequestNote(
+		pid any,
+		mergeRequest int64,
+		opt *gitlab.CreateMergeRequestNoteOptions,
+	) (*gitlab.Note, *gitlab.Response, error)
 }
 
 // MergeRequestsService interface for GitLab MergeRequests operations.

--- a/internal/app/mocks.go
+++ b/internal/app/mocks.go
@@ -167,6 +167,17 @@ func (m *MockNotesService) CreateIssueNote(
 	return note, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }
 
+func (m *MockNotesService) CreateMergeRequestNote(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.CreateMergeRequestNoteOptions,
+) (*gitlab.Note, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	note, _ := args.Get(0).(*gitlab.Note)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return note, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
 // MockMergeRequestsService is a mock implementation of MergeRequestsService.
 type MockMergeRequestsService struct {
 	mock.Mock


### PR DESCRIPTION
Implement add_merge_request_note tool to add comments to merge requests.
Follows the same pattern as add_issue_note for consistency.

- Add CreateMergeRequestNote to NotesService interface
- Implement AddMergeRequestNote business logic with validation
- Add MCP tool registration and handler
- Add error constants for merge request note validation
- Add comprehensive unit tests (5 test cases)
- Maintain 78.8% test coverage

Resolves #10