### PR TITLE
feat(epics): add list_epics tool for groups

### DIFF
--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -53,6 +53,16 @@ func (g *GitLabClientWrapper) Milestones() MilestonesService {
 	return &MilestonesServiceWrapper{service: g.client.Milestones}
 }
 
+// Groups returns the Groups service.
+func (g *GitLabClientWrapper) Groups() GroupsService {
+	return &GroupsServiceWrapper{service: g.client.Groups}
+}
+
+// Epics returns the Epics service.
+func (g *GitLabClientWrapper) Epics() EpicsService {
+	return &EpicsServiceWrapper{service: g.client.Epics}
+}
+
 // ProjectsServiceWrapper wraps the real Projects service.
 type ProjectsServiceWrapper struct {
 	service gitlab.ProjectsServiceInterface
@@ -215,4 +225,36 @@ func (m *MilestonesServiceWrapper) ListMilestones(
 		return nil, nil, fmt.Errorf("gitlab client: %w", err)
 	}
 	return milestones, resp, nil
+}
+
+// GroupsServiceWrapper wraps the real Groups service.
+type GroupsServiceWrapper struct {
+	service gitlab.GroupsServiceInterface
+}
+
+func (g *GroupsServiceWrapper) GetGroup(
+	gid any,
+	opt *gitlab.GetGroupOptions,
+) (*gitlab.Group, *gitlab.Response, error) {
+	group, resp, err := g.service.GetGroup(gid, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return group, resp, nil
+}
+
+// EpicsServiceWrapper wraps the real Epics service.
+type EpicsServiceWrapper struct {
+	service gitlab.EpicsServiceInterface
+}
+
+func (e *EpicsServiceWrapper) ListGroupEpics(
+	gid any,
+	opt *gitlab.ListGroupEpicsOptions,
+) ([]*gitlab.Epic, *gitlab.Response, error) {
+	epics, resp, err := e.service.ListGroupEpics(gid, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return epics, resp, nil
 }

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -10,6 +10,11 @@ type ProjectsService interface {
 	EditProject(pid any, opt *gitlab.EditProjectOptions) (*gitlab.Project, *gitlab.Response, error)
 }
 
+// GroupsService interface for GitLab Groups operations.
+type GroupsService interface {
+	GetGroup(gid any, opt *gitlab.GetGroupOptions) (*gitlab.Group, *gitlab.Response, error)
+}
+
 // IssuesService interface for GitLab Issues operations.
 type IssuesService interface {
 	ListProjectIssues(pid any, opt *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, *gitlab.Response, error)
@@ -55,6 +60,11 @@ type MilestonesService interface {
 	ListMilestones(pid any, opt *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, *gitlab.Response, error)
 }
 
+// EpicsService interface for GitLab Epics operations.
+type EpicsService interface {
+	ListGroupEpics(gid any, opt *gitlab.ListGroupEpicsOptions) ([]*gitlab.Epic, *gitlab.Response, error)
+}
+
 // GitLabClient interface that provides access to all GitLab services.
 type GitLabClient interface {
 	Projects() ProjectsService
@@ -64,4 +74,6 @@ type GitLabClient interface {
 	Notes() NotesService
 	MergeRequests() MergeRequestsService
 	Milestones() MilestonesService
+	Groups() GroupsService
+	Epics() EpicsService
 }

--- a/internal/app/mocks.go
+++ b/internal/app/mocks.go
@@ -56,6 +56,18 @@ func (m *MockGitLabClient) Milestones() MilestonesService {
 	return result
 }
 
+func (m *MockGitLabClient) Groups() GroupsService {
+	args := m.Called()
+	result, _ := args.Get(0).(GroupsService)
+	return result
+}
+
+func (m *MockGitLabClient) Epics() EpicsService {
+	args := m.Called()
+	result, _ := args.Get(0).(EpicsService)
+	return result
+}
+
 // MockProjectsService is a mock implementation of ProjectsService.
 type MockProjectsService struct {
 	mock.Mock
@@ -206,4 +218,34 @@ func (m *MockMilestonesService) ListMilestones(
 	milestones, _ := args.Get(0).([]*gitlab.Milestone)
 	response, _ := args.Get(1).(*gitlab.Response)
 	return milestones, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+// MockGroupsService is a mock implementation of GroupsService.
+type MockGroupsService struct {
+	mock.Mock
+}
+
+func (m *MockGroupsService) GetGroup(
+	gid any,
+	opt *gitlab.GetGroupOptions,
+) (*gitlab.Group, *gitlab.Response, error) {
+	args := m.Called(gid, opt)
+	group, _ := args.Get(0).(*gitlab.Group)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return group, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+// MockEpicsService is a mock implementation of EpicsService.
+type MockEpicsService struct {
+	mock.Mock
+}
+
+func (m *MockEpicsService) ListGroupEpics(
+	gid any,
+	opt *gitlab.ListGroupEpicsOptions,
+) ([]*gitlab.Epic, *gitlab.Response, error) {
+	args := m.Called(gid, opt)
+	epics, _ := args.Get(0).([]*gitlab.Epic)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return epics, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }


### PR DESCRIPTION
Add support for listing epics from GitLab groups and subgroups:
- Add ListGroupEpics method with state and limit filtering
- Add Epic struct with full field mapping
- Add GroupsService and EpicsService interfaces
- Handle Premium/Ultimate tier requirements with helpful errors
- Add user-friendly group path parameter

Refactor ListGroupEpics to reduce complexity:
- Extract resolveGroupID helper for group resolution
- Extract setDefaultEpicOptions for option handling
- Extract handleEpicsAPIError for error processing
- Reorder unexported methods to fix funcorder linter violations

All linter checks pass with 0 issues.