### PR TITLE
feat(epics): add add_issue_to_epic tool

### DIFF
--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -53,6 +53,11 @@ func (g *GitLabClientWrapper) Epics() EpicsService {
 	return &EpicsServiceWrapper{service: g.client.Epics}
 }
 
+// EpicIssues returns the EpicIssues service.
+func (g *GitLabClientWrapper) EpicIssues() EpicIssuesService {
+	return &EpicIssuesServiceWrapper{service: g.client.EpicIssues}
+}
+
 // ProjectsServiceWrapper wraps the real Projects service.
 type ProjectsServiceWrapper struct {
 	service gitlab.ProjectsServiceInterface
@@ -117,6 +122,17 @@ func (i *IssuesServiceWrapper) UpdateIssue(
 		return nil, nil, fmt.Errorf("gitlab client: %w", err)
 	}
 	return updatedIssue, resp, nil
+}
+
+func (i *IssuesServiceWrapper) GetIssue(
+	pid any,
+	issue int,
+) (*gitlab.Issue, *gitlab.Response, error) {
+	iss, resp, err := i.service.GetIssue(pid, int64(issue), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return iss, resp, nil
 }
 
 // LabelsServiceWrapper wraps the real Labels service.
@@ -214,4 +230,20 @@ func (e *EpicsServiceWrapper) CreateEpic(
 		return nil, nil, fmt.Errorf("gitlab client: %w", err)
 	}
 	return epic, resp, nil
+}
+
+// EpicIssuesServiceWrapper wraps the real EpicIssues service.
+type EpicIssuesServiceWrapper struct {
+	service gitlab.EpicIssuesServiceInterface
+}
+
+func (e *EpicIssuesServiceWrapper) AssignEpicIssue(
+	gid any,
+	epic, issue int64,
+) (*gitlab.EpicIssueAssignment, *gitlab.Response, error) {
+	epicIssue, resp, err := e.service.AssignEpicIssue(gid, epic, issue)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return epicIssue, resp, nil
 }

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -20,6 +20,7 @@ type IssuesService interface {
 	ListProjectIssues(pid any, opt *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, *gitlab.Response, error)
 	CreateIssue(pid any, opt *gitlab.CreateIssueOptions) (*gitlab.Issue, *gitlab.Response, error)
 	UpdateIssue(pid any, issue int64, opt *gitlab.UpdateIssueOptions) (*gitlab.Issue, *gitlab.Response, error)
+	GetIssue(pid any, issue int) (*gitlab.Issue, *gitlab.Response, error)
 }
 
 // LabelsService interface for GitLab Labels operations.
@@ -48,6 +49,11 @@ type EpicsService interface {
 	CreateEpic(gid any, opt *gitlab.CreateEpicOptions) (*gitlab.Epic, *gitlab.Response, error)
 }
 
+// EpicIssuesService interface for GitLab Epic Issues operations.
+type EpicIssuesService interface {
+	AssignEpicIssue(gid any, epic, issue int64) (*gitlab.EpicIssueAssignment, *gitlab.Response, error)
+}
+
 // GitLabClient interface that provides access to all GitLab services.
 type GitLabClient interface {
 	Projects() ProjectsService
@@ -57,4 +63,5 @@ type GitLabClient interface {
 	Notes() NotesService
 	Groups() GroupsService
 	Epics() EpicsService
+	EpicIssues() EpicIssuesService
 }

--- a/internal/app/mocks.go
+++ b/internal/app/mocks.go
@@ -56,6 +56,12 @@ func (m *MockGitLabClient) Epics() EpicsService {
 	return result
 }
 
+func (m *MockGitLabClient) EpicIssues() EpicIssuesService {
+	args := m.Called()
+	result, _ := args.Get(0).(EpicIssuesService)
+	return result
+}
+
 // MockProjectsService is a mock implementation of ProjectsService.
 type MockProjectsService struct {
 	mock.Mock
@@ -115,6 +121,16 @@ func (m *MockIssuesService) UpdateIssue(
 	updatedIssue, _ := args.Get(0).(*gitlab.Issue)
 	response, _ := args.Get(1).(*gitlab.Response)
 	return updatedIssue, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockIssuesService) GetIssue(
+	pid any,
+	issue int,
+) (*gitlab.Issue, *gitlab.Response, error) {
+	args := m.Called(pid, issue)
+	iss, _ := args.Get(0).(*gitlab.Issue)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return iss, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }
 
 // MockLabelsService is a mock implementation of LabelsService.
@@ -209,4 +225,23 @@ func (m *MockEpicsService) CreateEpic(
 	epic, _ := args.Get(0).(*gitlab.Epic)
 	response, _ := args.Get(1).(*gitlab.Response)
 	return epic, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+// MockEpicIssuesService is a mock implementation of EpicIssuesService.
+type MockEpicIssuesService struct {
+	mock.Mock
+}
+
+func (m *MockEpicIssuesService) AssignEpicIssue(
+	gid any,
+	epic, issue int64,
+) (*gitlab.EpicIssueAssignment, *gitlab.Response, error) {
+	args := m.Called(gid, epic, issue)
+	if args.Get(0) == nil {
+		response, _ := args.Get(1).(*gitlab.Response)
+		return nil, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+	}
+	epicIssue, _ := args.Get(0).(*gitlab.EpicIssueAssignment)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return epicIssue, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }


### PR DESCRIPTION
Implement tool to attach issues to epics (Premium/Ultimate tier)

- Add EpicIssuesService interface with AssignEpicIssue method
- Add GetIssue method to IssuesService for issue ID resolution
- Implement AddIssueToEpic business logic with validation
- Add EpicIssueAssignment struct for response data
- Create add_issue_to_epic MCP tool with parameter extraction
- Add comprehensive error handling with static error variables
- Include mock implementations for testing
- Add API deprecation notice in tool description

The tool resolves group paths, project paths, and issue IIDs to
the numeric IDs required by the GitLab API. Handles 403 Forbidden
errors gracefully for tier requirements.