### PR TITLE
feat(merge-requests): add merge request management tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,14 @@ This is a Model Context Protocol (MCP) server that provides GitLab integration t
 - `list_pipeline_jobs`: Lists all jobs for a GitLab pipeline with filtering options (status, stage)
 - `get_job_log`: Retrieves complete log output for a specific CI/CD job with job metadata
 - `download_job_trace`: Downloads CI/CD job logs to local files for offline analysis and archiving
+- `list_merge_requests`: Lists merge requests for a GitLab project with filtering options (state, labels, author, search)
+- `create_merge_request`: Creates a new merge request with title, source/target branches, description, labels, assignees, and reviewers
+- `get_merge_request`: Gets details of a specific merge request by IID
+- `update_merge_request`: Updates an existing merge request (title, description, state, labels, assignees, reviewers)
+- `merge_merge_request`: Merges an approved merge request with squash and remove-source-branch options
+- `get_merge_request_diff`: Gets the unified diff for a merge request showing actual code changes per file
+- `approve_merge_request`: Approves a merge request with optional SHA verification
+- `add_merge_request_note`: Adds a comment/note to a merge request
 
 ## Architecture
 
@@ -38,6 +46,14 @@ The codebase follows a clean architecture pattern with clear separation of conce
   - Public methods for each tool operation (e.g., `ListProjectIssues`, `CreateProjectIssue`)
   - Private helper methods for validation
   - Interface-based design for testability via dependency injection
+
+- **internal/app/merge_requests.go**: Business logic for merge request operations
+  - CRUD operations, merging, diffs, approvals, and notes for merge requests
+  - Converts GitLab API types to internal MergeRequest representation
+
+- **merge_request_tools.go**: MCP tool definitions and handlers for merge request operations
+  - Tool registration functions (`setup*Tool()`) for all 8 merge request tools
+  - Parameter parsing helpers (`parseListMROptions`, `parseUpdateMROptions`, `parseLabels`, `parseIDArray`)
 
 - **internal/app/interfaces.go**: Interface definitions for GitLab client abstraction
   - Defines service interfaces matching GitLab API structure
@@ -185,6 +201,35 @@ Download the log for job 11111 from the develop branch to /tmp/build.log
 
 The tool handles the resolution automatically - no need to look up user IDs or milestone IDs manually.
 
+**Managing merge requests:**
+```
+List open merge requests for myorg/myproject
+```
+
+```
+Create a merge request from feature-branch to main in myorg/myproject with title "Add user authentication"
+```
+
+```
+Get details of merge request 42 in myorg/myproject
+```
+
+```
+Get the diff for merge request 42 in myorg/myproject
+```
+
+```
+Approve merge request 42 in myorg/myproject
+```
+
+```
+Merge merge request 42 in myorg/myproject with squash enabled and remove source branch
+```
+
+```
+Add a comment to merge request 42 in myorg/myproject: "LGTM, approved!"
+```
+
 ## CLI Flags for Token Optimization
 
 The server supports CLI flags to disable tool categories, reducing token consumption for specialized use cases:
@@ -196,22 +241,28 @@ The server supports CLI flags to disable tool categories, reducing token consump
 - `--no-project-metadata` - Disable project metadata tools (4 tools)
 - `--no-epics` - Disable epic management tools (3 tools)
 - `--no-pipelines` - Disable CI/CD pipeline tools (4 tools)
+- `--no-merge-requests` - Disable merge request management tools (8 tools)
 
 ### Usage Examples
 
 **CI/CD debugging agent (only pipeline tools):**
 ```bash
-gitlab-mcp --no-issues --no-labels --no-project-metadata --no-epics
+gitlab-mcp --no-issues --no-labels --no-project-metadata --no-epics --no-merge-requests
 ```
 
 **Documentation agent (only project metadata):**
 ```bash
-gitlab-mcp --no-issues --no-labels --no-epics --no-pipelines
+gitlab-mcp --no-issues --no-labels --no-epics --no-pipelines --no-merge-requests
 ```
 
 **Issue triage bot (only issues and labels):**
 ```bash
-gitlab-mcp --no-project-metadata --no-epics --no-pipelines
+gitlab-mcp --no-project-metadata --no-epics --no-pipelines --no-merge-requests
+```
+
+**MR review agent (only merge request and pipeline tools):**
+```bash
+gitlab-mcp --no-issues --no-labels --no-project-metadata --no-epics
 ```
 
 ### Configuration with Claude Code
@@ -300,7 +351,7 @@ Located in `internal/app/app_test.go` and `internal/logger/logger_test.go`, thes
 The codebase uses dependency injection via interfaces for testability:
 - **Interfaces**: Defined in `internal/app/interfaces.go` for GitLab client abstraction
   - `GitLabClient`: Main interface wrapping all GitLab service interfaces
-  - Service-specific interfaces: `ProjectsService`, `IssuesService`, `LabelsService`, `UsersService`, `NotesService`, `MergeRequestsService`, `MilestonesService`
+  - Service-specific interfaces: `ProjectsService`, `IssuesService`, `LabelsService`, `UsersService`, `NotesService`, `MergeRequestsService`, `MergeRequestApprovalsService`, `MilestonesService`
 - **Production Implementation**: `internal/app/client.go` wraps the real GitLab client
 - **Mocks**: Generated in `internal/app/mocks.go` using testify/mock
 - **Test Constructor**: Use `NewWithClient()` in tests to inject mocked GitLabClient
@@ -370,7 +421,13 @@ The server uses the official GitLab Go client to interact with GitLab's REST API
 - **Labels List**: `/projects/:id/labels` endpoint for label retrieval
 - **Filtering**: Supports state filtering, label filtering, search, and pagination
 - **Deduplication**: Group issues are filtered to exclude duplicates from the current project
-- **Response Format**: Returns structured JSON with issue, label, note, and project metadata
+- **Merge Requests List**: `/projects/:id/merge_requests` endpoint for MR retrieval
+- **Merge Request CRUD**: `/projects/:id/merge_requests/:mr_iid` endpoint for get/create/update operations
+- **Merge Request Merge**: `/projects/:id/merge_requests/:mr_iid/merge` endpoint for accepting MRs
+- **Merge Request Diffs**: `/projects/:id/merge_requests/:mr_iid/diffs` endpoint for file-level diffs
+- **Merge Request Approvals**: `/projects/:id/merge_requests/:mr_iid/approve` endpoint for approvals
+- **Merge Request Notes**: `/projects/:id/merge_requests/:mr_iid/notes` endpoint for comments
+- **Response Format**: Returns structured JSON with issue, label, note, merge request, and project metadata
 
 ### MCP Protocol Implementation
 - Uses `github.com/mark3labs/mcp-go` for server implementation
@@ -394,9 +451,17 @@ Unit tests provide comprehensive coverage of all functionality:
 - `ListProjectLabels`: Label retrieval with optional filtering, search, and counts
 - `GetLatestPipeline`: Pipeline retrieval with ref filtering and error scenarios
 - `ListPipelineJobs`: Job listing with pipeline ID resolution, status/stage filtering, and comprehensive error handling
-- Edge cases: nil parameters, empty values, API errors, project not found, invalid issue IIDs
+- `ListProjectMergeRequests`: MR retrieval with state filtering, label/author/search filters, and error scenarios
+- `CreateProjectMergeRequest`: MR creation with required/optional fields validation and error handling
+- `GetMergeRequest`: MR detail retrieval with IID validation and error handling
+- `UpdateMergeRequest`: MR updates with partial/full field updates and validation
+- `MergeMergeRequest`: MR merging with squash/remove-source-branch options and error scenarios
+- `GetMergeRequestDiff`: Diff retrieval with formatted unified diff output for new/modified/deleted files
+- `ApproveMergeRequest`: MR approval with optional SHA verification and error handling
+- `AddMergeRequestNote`: MR note creation with body validation and error handling
+- Edge cases: nil parameters, empty values, API errors, project not found, invalid IIDs
 
-All tests run without external dependencies using mocked GitLab client interfaces. Current test coverage is **72.7%**.
+All tests run without external dependencies using mocked GitLab client interfaces. Current test coverage is **83.1%**.
 
 ### Group Issues Integration
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -380,6 +380,76 @@ type DownloadJobTraceResult struct {
 	SavedAt    string `json:"saved_at"`    // ISO 8601 timestamp
 }
 
+// MergeRequest represents a GitLab merge request.
+type MergeRequest struct {
+	ID             int64          `json:"id"`
+	IID            int64          `json:"iid"`
+	Title          string         `json:"title"`
+	Description    string         `json:"description"`
+	State          string         `json:"state"`
+	SourceBranch   string         `json:"source_branch"`
+	TargetBranch   string         `json:"target_branch"`
+	Author         map[string]any `json:"author"`
+	Assignees      []map[string]any `json:"assignees,omitempty"`
+	Reviewers      []map[string]any `json:"reviewers,omitempty"`
+	Labels         []string       `json:"labels"`
+	WebURL         string         `json:"web_url"`
+	MergeStatus    string         `json:"merge_status"`
+	Draft          bool           `json:"draft"`
+	WorkInProgress bool           `json:"work_in_progress"`
+	CreatedAt      string         `json:"created_at"`
+	UpdatedAt      string         `json:"updated_at"`
+}
+
+// ListMergeRequestsOptions contains options for listing merge requests.
+type ListMergeRequestsOptions struct {
+	State  string   // opened, closed, locked, merged
+	Labels []string // Filter by labels
+	Author string   // Filter by author username
+	Search string   // Search in title and description
+	Limit  int64    // Max results to return
+}
+
+// CreateMergeRequestOptions contains options for creating a merge request.
+type CreateMergeRequestOptions struct {
+	Title        string   // Required
+	SourceBranch string   // Required
+	TargetBranch string   // Required
+	Description  string   // Optional
+	Labels       []string // Optional
+	AssigneeIDs  []int64  // Optional
+	ReviewerIDs  []int64  // Optional
+}
+
+// UpdateMergeRequestOptions contains options for updating a merge request.
+type UpdateMergeRequestOptions struct {
+	Title       string   // Optional
+	Description string   // Optional
+	State       string   // Optional: opened, closed
+	Labels      []string // Optional
+	AssigneeIDs []int64  // Optional
+	ReviewerIDs []int64  // Optional
+}
+
+// MergeMergeRequestOptions contains options for merging a merge request.
+type MergeMergeRequestOptions struct {
+	MergeCommitMessage       string // Optional
+	SquashCommitMessage      string // Optional
+	Squash                   bool   // Optional
+	ShouldRemoveSourceBranch bool   // Optional
+	MergeWhenPipelineSucceeds bool  // Optional
+}
+
+// AddMergeRequestNoteOptions contains options for adding a note to a merge request.
+type AddMergeRequestNoteOptions struct {
+	Body string // Required
+}
+
+// ApproveMergeRequestOptions contains options for approving a merge request.
+type ApproveMergeRequestOptions struct {
+	SHA string // Optional: specific SHA to approve
+}
+
 // parseLabels splits comma-separated labels and trims spaces.
 func parseLabels(labels string) []string {
 	parts := strings.Split(labels, ",")

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -74,6 +74,16 @@ func (g *GitLabClientWrapper) GroupLabels() GroupLabelsService {
 	return &GroupLabelsServiceWrapper{service: g.client.GroupLabels}
 }
 
+// MergeRequests returns the MergeRequests service.
+func (g *GitLabClientWrapper) MergeRequests() MergeRequestsService {
+	return &MergeRequestsServiceWrapper{service: g.client.MergeRequests}
+}
+
+// MergeRequestApprovals returns the MergeRequestApprovals service.
+func (g *GitLabClientWrapper) MergeRequestApprovals() MergeRequestApprovalsService {
+	return &MergeRequestApprovalsServiceWrapper{service: g.client.MergeRequestApprovals}
+}
+
 // ProjectsServiceWrapper wraps the real Projects service.
 type ProjectsServiceWrapper struct {
 	service gitlab.ProjectsServiceInterface
@@ -217,6 +227,18 @@ func (n *NotesServiceWrapper) CreateIssueNote(
 	return note, resp, nil
 }
 
+func (n *NotesServiceWrapper) CreateMergeRequestNote(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.CreateMergeRequestNoteOptions,
+) (*gitlab.Note, *gitlab.Response, error) {
+	note, resp, err := n.service.CreateMergeRequestNote(pid, mergeRequest, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return note, resp, nil
+}
+
 // GroupsServiceWrapper wraps the real Groups service.
 type GroupsServiceWrapper struct {
 	service gitlab.GroupsServiceInterface
@@ -347,4 +369,116 @@ func (j *JobsServiceWrapper) GetTraceFile(
 		return nil, nil, fmt.Errorf("gitlab client: %w", err)
 	}
 	return trace, resp, nil
+}
+
+// MergeRequestsServiceWrapper wraps the real MergeRequests service.
+type MergeRequestsServiceWrapper struct {
+	service gitlab.MergeRequestsServiceInterface
+}
+
+func (m *MergeRequestsServiceWrapper) ListProjectMergeRequests(
+	pid any,
+	opt *gitlab.ListProjectMergeRequestsOptions,
+) ([]*gitlab.MergeRequest, *gitlab.Response, error) {
+	basicMRs, resp, err := m.service.ListProjectMergeRequests(pid, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+
+	// Convert BasicMergeRequest to MergeRequest directly via embedding.
+	// All fields used by convertGitLabMergeRequest are present in BasicMergeRequest.
+	mrs := make([]*gitlab.MergeRequest, 0, len(basicMRs))
+	for _, basicMR := range basicMRs {
+		mrs = append(mrs, &gitlab.MergeRequest{BasicMergeRequest: *basicMR})
+	}
+
+	return mrs, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) CreateMergeRequest(
+	pid any,
+	opt *gitlab.CreateMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	mr, resp, err := m.service.CreateMergeRequest(pid, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return mr, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) GetMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.GetMergeRequestsOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	mr, resp, err := m.service.GetMergeRequest(pid, int64(mergeRequest), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return mr, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) UpdateMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.UpdateMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	mr, resp, err := m.service.UpdateMergeRequest(pid, int64(mergeRequest), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return mr, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) AcceptMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.AcceptMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	mr, resp, err := m.service.AcceptMergeRequest(pid, int64(mergeRequest), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return mr, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) GetMergeRequestDiffVersions(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.GetMergeRequestDiffVersionsOptions,
+) ([]*gitlab.MergeRequestDiffVersion, *gitlab.Response, error) {
+	diffs, resp, err := m.service.GetMergeRequestDiffVersions(pid, int64(mergeRequest), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return diffs, resp, nil
+}
+
+func (m *MergeRequestsServiceWrapper) ListMergeRequestDiffs(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.ListMergeRequestDiffsOptions,
+) ([]*gitlab.MergeRequestDiff, *gitlab.Response, error) {
+	diffs, resp, err := m.service.ListMergeRequestDiffs(pid, int64(mergeRequest), opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return diffs, resp, nil
+}
+
+// MergeRequestApprovalsServiceWrapper wraps the real MergeRequestApprovals service.
+type MergeRequestApprovalsServiceWrapper struct {
+	service gitlab.MergeRequestApprovalsServiceInterface
+}
+
+func (m *MergeRequestApprovalsServiceWrapper) ApproveMergeRequest(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.ApproveMergeRequestOptions,
+) (*gitlab.MergeRequestApprovals, *gitlab.Response, error) {
+	approvals, resp, err := m.service.ApproveMergeRequest(pid, mergeRequest, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return approvals, resp, nil
 }

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -60,6 +60,11 @@ type NotesService interface {
 		issue int64,
 		opt *gitlab.CreateIssueNoteOptions,
 	) (*gitlab.Note, *gitlab.Response, error)
+	CreateMergeRequestNote(
+		pid any,
+		mergeRequest int64,
+		opt *gitlab.CreateMergeRequestNoteOptions,
+	) (*gitlab.Note, *gitlab.Response, error)
 }
 
 // EpicsService interface for GitLab Epics operations.
@@ -96,6 +101,52 @@ type JobsService interface {
 	) (io.Reader, *gitlab.Response, error)
 }
 
+// MergeRequestsService interface for GitLab Merge Requests operations.
+type MergeRequestsService interface {
+	ListProjectMergeRequests(
+		pid any,
+		opt *gitlab.ListProjectMergeRequestsOptions,
+	) ([]*gitlab.MergeRequest, *gitlab.Response, error)
+	CreateMergeRequest(
+		pid any,
+		opt *gitlab.CreateMergeRequestOptions,
+	) (*gitlab.MergeRequest, *gitlab.Response, error)
+	GetMergeRequest(
+		pid any,
+		mergeRequest int,
+		opt *gitlab.GetMergeRequestsOptions,
+	) (*gitlab.MergeRequest, *gitlab.Response, error)
+	UpdateMergeRequest(
+		pid any,
+		mergeRequest int,
+		opt *gitlab.UpdateMergeRequestOptions,
+	) (*gitlab.MergeRequest, *gitlab.Response, error)
+	AcceptMergeRequest(
+		pid any,
+		mergeRequest int,
+		opt *gitlab.AcceptMergeRequestOptions,
+	) (*gitlab.MergeRequest, *gitlab.Response, error)
+	GetMergeRequestDiffVersions(
+		pid any,
+		mergeRequest int,
+		opt *gitlab.GetMergeRequestDiffVersionsOptions,
+	) ([]*gitlab.MergeRequestDiffVersion, *gitlab.Response, error)
+	ListMergeRequestDiffs(
+		pid any,
+		mergeRequest int,
+		opt *gitlab.ListMergeRequestDiffsOptions,
+	) ([]*gitlab.MergeRequestDiff, *gitlab.Response, error)
+}
+
+// MergeRequestApprovalsService interface for GitLab Merge Request Approvals operations.
+type MergeRequestApprovalsService interface {
+	ApproveMergeRequest(
+		pid any,
+		mergeRequest int64,
+		opt *gitlab.ApproveMergeRequestOptions,
+	) (*gitlab.MergeRequestApprovals, *gitlab.Response, error)
+}
+
 // GitLabClient interface that provides access to all GitLab services.
 type GitLabClient interface {
 	Projects() ProjectsService
@@ -109,4 +160,6 @@ type GitLabClient interface {
 	EpicIssues() EpicIssuesService
 	Pipelines() PipelinesService
 	Jobs() JobsService
+	MergeRequests() MergeRequestsService
+	MergeRequestApprovals() MergeRequestApprovalsService
 }

--- a/internal/app/merge_requests.go
+++ b/internal/app/merge_requests.go
@@ -1,0 +1,490 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// Error variables for merge request operations.
+var (
+	ErrMRTitleRequired      = errors.New("merge request title is required")
+	ErrSourceBranchRequired = errors.New("source branch is required")
+	ErrTargetBranchRequired = errors.New("target branch is required")
+	ErrMROptionsRequired    = errors.New("merge request options are required")
+	ErrInvalidMRIID         = errors.New("merge request IID must be positive")
+)
+
+const (
+	maxMergeRequestsPerPage = 100
+)
+
+// buildListMergeRequestsOptions converts our options to GitLab API options.
+func buildListMergeRequestsOptions(opts *ListMergeRequestsOptions) *gitlab.ListProjectMergeRequestsOptions {
+	listOpts := &gitlab.ListProjectMergeRequestsOptions{
+		ListOptions: gitlab.ListOptions{PerPage: maxMergeRequestsPerPage, Page: 1},
+	}
+
+	if opts == nil {
+		return listOpts
+	}
+
+	if opts.State != "" {
+		listOpts.State = gitlab.Ptr(opts.State)
+	}
+	if len(opts.Labels) > 0 {
+		labels := gitlab.LabelOptions(opts.Labels)
+		listOpts.Labels = &labels
+	}
+	if opts.Author != "" {
+		listOpts.AuthorUsername = gitlab.Ptr(opts.Author)
+	}
+	if opts.Search != "" {
+		listOpts.Search = gitlab.Ptr(opts.Search)
+	}
+	if opts.Limit > 0 {
+		listOpts.PerPage = min(opts.Limit, maxMergeRequestsPerPage)
+	}
+
+	return listOpts
+}
+
+// buildAcceptMergeRequestOptions converts our options to GitLab API options.
+func buildAcceptMergeRequestOptions(opts *MergeMergeRequestOptions) *gitlab.AcceptMergeRequestOptions {
+	acceptOpts := &gitlab.AcceptMergeRequestOptions{}
+
+	if opts == nil {
+		return acceptOpts
+	}
+
+	if opts.MergeCommitMessage != "" {
+		acceptOpts.MergeCommitMessage = gitlab.Ptr(opts.MergeCommitMessage)
+	}
+	if opts.SquashCommitMessage != "" {
+		acceptOpts.SquashCommitMessage = gitlab.Ptr(opts.SquashCommitMessage)
+	}
+	if opts.Squash {
+		acceptOpts.Squash = gitlab.Ptr(opts.Squash)
+	}
+	if opts.ShouldRemoveSourceBranch {
+		acceptOpts.ShouldRemoveSourceBranch = gitlab.Ptr(opts.ShouldRemoveSourceBranch)
+	}
+	if opts.MergeWhenPipelineSucceeds {
+		acceptOpts.AutoMerge = gitlab.Ptr(opts.MergeWhenPipelineSucceeds)
+	}
+
+	return acceptOpts
+}
+
+// buildCreateMergeRequestOptions converts our options to GitLab API options.
+func buildCreateMergeRequestOptions(opts *CreateMergeRequestOptions) *gitlab.CreateMergeRequestOptions {
+	createOpts := &gitlab.CreateMergeRequestOptions{
+		Title:        gitlab.Ptr(opts.Title),
+		SourceBranch: gitlab.Ptr(opts.SourceBranch),
+		TargetBranch: gitlab.Ptr(opts.TargetBranch),
+	}
+
+	if opts.Description != "" {
+		createOpts.Description = gitlab.Ptr(opts.Description)
+	}
+	if len(opts.Labels) > 0 {
+		labels := gitlab.LabelOptions(opts.Labels)
+		createOpts.Labels = &labels
+	}
+	if len(opts.AssigneeIDs) > 0 {
+		createOpts.AssigneeIDs = &opts.AssigneeIDs
+	}
+	if len(opts.ReviewerIDs) > 0 {
+		createOpts.ReviewerIDs = &opts.ReviewerIDs
+	}
+
+	return createOpts
+}
+
+// buildUpdateMergeRequestOptions converts our options to GitLab API options.
+func buildUpdateMergeRequestOptions(opts *UpdateMergeRequestOptions) *gitlab.UpdateMergeRequestOptions {
+	updateOpts := &gitlab.UpdateMergeRequestOptions{}
+
+	if opts.Title != "" {
+		updateOpts.Title = gitlab.Ptr(opts.Title)
+	}
+	if opts.Description != "" {
+		updateOpts.Description = gitlab.Ptr(opts.Description)
+	}
+	if opts.State != "" {
+		updateOpts.StateEvent = gitlab.Ptr(opts.State)
+	}
+	if opts.Labels != nil {
+		labels := gitlab.LabelOptions(opts.Labels)
+		updateOpts.Labels = &labels
+	}
+	if opts.AssigneeIDs != nil {
+		updateOpts.AssigneeIDs = &opts.AssigneeIDs
+	}
+	if opts.ReviewerIDs != nil {
+		updateOpts.ReviewerIDs = &opts.ReviewerIDs
+	}
+
+	return updateOpts
+}
+
+// ListProjectMergeRequests lists merge requests for a GitLab project.
+func (a *App) ListProjectMergeRequests(
+	projectPath string,
+	opts *ListMergeRequestsOptions,
+) ([]MergeRequest, error) {
+	a.logger.Debug("Listing merge requests", "project_path", projectPath, "options", opts)
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return nil, fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Build GitLab API options
+	listOpts := buildListMergeRequestsOptions(opts)
+
+	// Call GitLab API
+	mrs, _, err := a.client.MergeRequests().ListProjectMergeRequests(projectID, listOpts)
+	if err != nil {
+		a.logger.Error("Failed to list merge requests", "error", err, "project_id", projectID)
+		return nil, fmt.Errorf("failed to list merge requests for project %s: %w", projectPath, err)
+	}
+
+	// Convert to our MergeRequest type
+	result := make([]MergeRequest, 0, len(mrs))
+	for _, mr := range mrs {
+		result = append(result, convertGitLabMergeRequest(mr))
+	}
+
+	a.logger.Info("Successfully listed merge requests", "count", len(result), "project_path", projectPath)
+	return result, nil
+}
+
+// CreateProjectMergeRequest creates a new merge request.
+func (a *App) CreateProjectMergeRequest(
+	projectPath string,
+	opts *CreateMergeRequestOptions,
+) (*MergeRequest, error) {
+	// Validate options
+	if opts == nil {
+		return nil, ErrMROptionsRequired
+	}
+
+	a.logger.Debug("Creating merge request", "project_path", projectPath, "title", opts.Title)
+	if opts.Title == "" {
+		return nil, ErrMRTitleRequired
+	}
+	if opts.SourceBranch == "" {
+		return nil, ErrSourceBranchRequired
+	}
+	if opts.TargetBranch == "" {
+		return nil, ErrTargetBranchRequired
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return nil, fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Build GitLab API options
+	createOpts := buildCreateMergeRequestOptions(opts)
+
+	// Call GitLab API
+	mr, _, err := a.client.MergeRequests().CreateMergeRequest(projectID, createOpts)
+	if err != nil {
+		a.logger.Error("Failed to create merge request", "error", err, "project_id", projectID)
+		return nil, fmt.Errorf("failed to create merge request in project %s: %w", projectPath, err)
+	}
+
+	result := convertGitLabMergeRequest(mr)
+	a.logger.Info("Successfully created merge request", "mr_iid", result.IID, "project_path", projectPath)
+	return &result, nil
+}
+
+// GetMergeRequest gets details of a specific merge request.
+func (a *App) GetMergeRequest(projectPath string, mrIID int64) (*MergeRequest, error) {
+	a.logger.Debug("Getting merge request", "project_path", projectPath, "mr_iid", mrIID)
+
+	if mrIID <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return nil, fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Call GitLab API
+	mr, _, err := a.client.MergeRequests().GetMergeRequest(projectID, int(mrIID), nil)
+	if err != nil {
+		a.logger.Error("Failed to get merge request", "error", err, "mr_iid", mrIID)
+		return nil, fmt.Errorf("failed to get merge request %d in project %s: %w", mrIID, projectPath, err)
+	}
+
+	result := convertGitLabMergeRequest(mr)
+	a.logger.Info("Successfully retrieved merge request", "mr_iid", mrIID, "project_path", projectPath)
+	return &result, nil
+}
+
+// UpdateMergeRequest updates an existing merge request.
+func (a *App) UpdateMergeRequest(
+	projectPath string,
+	mrIID int64,
+	opts *UpdateMergeRequestOptions,
+) (*MergeRequest, error) {
+	a.logger.Debug("Updating merge request", "project_path", projectPath, "mr_iid", mrIID)
+
+	if mrIID <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+	if opts == nil {
+		return nil, ErrMROptionsRequired
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return nil, fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Build GitLab API options
+	updateOpts := buildUpdateMergeRequestOptions(opts)
+
+	// Call GitLab API
+	mr, _, err := a.client.MergeRequests().UpdateMergeRequest(projectID, int(mrIID), updateOpts)
+	if err != nil {
+		a.logger.Error("Failed to update merge request", "error", err, "mr_iid", mrIID)
+		return nil, fmt.Errorf("failed to update merge request %d in project %s: %w", mrIID, projectPath, err)
+	}
+
+	result := convertGitLabMergeRequest(mr)
+	a.logger.Info("Successfully updated merge request", "mr_iid", mrIID, "project_path", projectPath)
+	return &result, nil
+}
+
+// MergeMergeRequest merges an approved merge request.
+func (a *App) MergeMergeRequest(
+	projectPath string,
+	mrIID int64,
+	opts *MergeMergeRequestOptions,
+) (*MergeRequest, error) {
+	a.logger.Debug("Merging merge request", "project_path", projectPath, "mr_iid", mrIID)
+
+	if mrIID <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return nil, fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Build GitLab API options
+	acceptOpts := buildAcceptMergeRequestOptions(opts)
+
+	// Call GitLab API
+	mr, _, err := a.client.MergeRequests().AcceptMergeRequest(projectID, int(mrIID), acceptOpts)
+	if err != nil {
+		a.logger.Error("Failed to merge request", "error", err, "mr_iid", mrIID)
+		return nil, fmt.Errorf("failed to merge request %d in project %s: %w", mrIID, projectPath, err)
+	}
+
+	result := convertGitLabMergeRequest(mr)
+	a.logger.Info("Successfully merged merge request", "mr_iid", mrIID, "project_path", projectPath)
+	return &result, nil
+}
+
+// GetMergeRequestDiff gets the diff for a merge request.
+func (a *App) GetMergeRequestDiff(projectPath string, mrIID int64) (string, error) {
+	a.logger.Debug("Getting merge request diff", "project_path", projectPath, "mr_iid", mrIID)
+
+	if mrIID <= 0 {
+		return "", fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return "", fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Call GitLab API to get actual file-level diffs
+	diffs, _, err := a.client.MergeRequests().ListMergeRequestDiffs(projectID, int(mrIID), nil)
+	if err != nil {
+		a.logger.Error("Failed to get merge request diff", "error", err, "mr_iid", mrIID)
+		return "", fmt.Errorf("failed to get diff for merge request %d in project %s: %w", mrIID, projectPath, err)
+	}
+
+	if len(diffs) == 0 {
+		return "No diffs available for this merge request", nil
+	}
+
+	// Format diffs into unified diff output
+	var result strings.Builder
+	for i, diff := range diffs {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		switch {
+		case diff.NewFile:
+			fmt.Fprintf(&result, "--- /dev/null\n+++ b/%s\n", diff.NewPath)
+		case diff.DeletedFile:
+			fmt.Fprintf(&result, "--- a/%s\n+++ /dev/null\n", diff.OldPath)
+		default:
+			fmt.Fprintf(&result, "--- a/%s\n+++ b/%s\n", diff.OldPath, diff.NewPath)
+		}
+		result.WriteString(diff.Diff)
+	}
+
+	a.logger.Info("Successfully retrieved merge request diff",
+		"mr_iid", mrIID, "project_path", projectPath, "files_changed", len(diffs))
+	return result.String(), nil
+}
+
+// ApproveMergeRequest approves a merge request.
+func (a *App) ApproveMergeRequest(
+	projectPath string,
+	mrIID int64,
+	opts *ApproveMergeRequestOptions,
+) (string, error) {
+	a.logger.Debug("Approving merge request", "project_path", projectPath, "mr_iid", mrIID)
+
+	if mrIID <= 0 {
+		return "", fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+
+	// Get project by path
+	project, _, err := a.client.Projects().GetProject(projectPath, nil)
+	if err != nil {
+		a.logger.Error("Failed to get project", "error", err, "project_path", projectPath)
+		return "", fmt.Errorf("failed to get project %s: %w", projectPath, err)
+	}
+	projectID := project.ID
+
+	// Build GitLab API options
+	approveOpts := &gitlab.ApproveMergeRequestOptions{}
+	if opts != nil && opts.SHA != "" {
+		approveOpts.SHA = gitlab.Ptr(opts.SHA)
+	}
+
+	// Call GitLab API
+	approvals, _, err := a.client.MergeRequestApprovals().ApproveMergeRequest(projectID, mrIID, approveOpts)
+	if err != nil {
+		a.logger.Error("Failed to approve merge request", "error", err, "mr_iid", mrIID)
+		return "", fmt.Errorf("failed to approve merge request %d in project %s: %w", mrIID, projectPath, err)
+	}
+
+	result := fmt.Sprintf("Merge request %d approved successfully. Approvals: %d/%d",
+		mrIID, len(approvals.ApprovedBy), approvals.ApprovalsRequired)
+
+	a.logger.Info("Successfully approved merge request", "mr_iid", mrIID, "project_path", projectPath)
+	return result, nil
+}
+
+// AddMergeRequestNote adds a comment/note to a merge request.
+func (a *App) AddMergeRequestNote(
+	projectPath string,
+	mrIID int64,
+	opts *AddMergeRequestNoteOptions,
+) (*Note, error) {
+	a.logger.Debug("Adding merge request note", "project_path", projectPath, "mr_iid", mrIID)
+
+	if opts == nil || opts.Body == "" {
+		return nil, ErrNoteBodyRequired
+	}
+	if mrIID <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidMRIID, mrIID)
+	}
+
+	// Use common note creation helper
+	return a.addNoteCommon(projectPath, mrIID, opts.Body, "merge request",
+		func(projectID int64, iid int64, body string) (*gitlab.Note, error) {
+			createOpts := &gitlab.CreateMergeRequestNoteOptions{
+				Body: gitlab.Ptr(body),
+			}
+			note, _, err := a.client.Notes().CreateMergeRequestNote(projectID, iid, createOpts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create merge request note: %w", err)
+			}
+			return note, nil
+		})
+}
+
+// convertGitLabMergeRequest converts a GitLab merge request to our MergeRequest struct.
+func convertGitLabMergeRequest(mr *gitlab.MergeRequest) MergeRequest {
+	result := MergeRequest{
+		ID:             mr.ID,
+		IID:            mr.IID,
+		Title:          mr.Title,
+		Description:    mr.Description,
+		State:          mr.State,
+		SourceBranch:   mr.SourceBranch,
+		TargetBranch:   mr.TargetBranch,
+		Labels:         mr.Labels,
+		WebURL:         mr.WebURL,
+		MergeStatus:    mr.DetailedMergeStatus,
+		Draft:          mr.Draft,
+		WorkInProgress: mr.Draft,  // Draft is the new field
+	}
+
+	// Convert author
+	if mr.Author != nil {
+		result.Author = map[string]any{
+			"id":       mr.Author.ID,
+			"username": mr.Author.Username,
+			"name":     mr.Author.Name,
+		}
+	}
+
+	// Convert assignees
+	if len(mr.Assignees) > 0 {
+		result.Assignees = make([]map[string]any, 0, len(mr.Assignees))
+		for _, assignee := range mr.Assignees {
+			result.Assignees = append(result.Assignees, map[string]any{
+				"id":       assignee.ID,
+				"username": assignee.Username,
+				"name":     assignee.Name,
+			})
+		}
+	}
+
+	// Convert reviewers
+	if len(mr.Reviewers) > 0 {
+		result.Reviewers = make([]map[string]any, 0, len(mr.Reviewers))
+		for _, reviewer := range mr.Reviewers {
+			result.Reviewers = append(result.Reviewers, map[string]any{
+				"id":       reviewer.ID,
+				"username": reviewer.Username,
+				"name":     reviewer.Name,
+			})
+		}
+	}
+
+	// Convert timestamps
+	if mr.CreatedAt != nil {
+		result.CreatedAt = mr.CreatedAt.Format("2006-01-02T15:04:05Z")
+	}
+	if mr.UpdatedAt != nil {
+		result.UpdatedAt = mr.UpdatedAt.Format("2006-01-02T15:04:05Z")
+	}
+
+	return result
+}

--- a/internal/app/merge_requests_test.go
+++ b/internal/app/merge_requests_test.go
@@ -1,0 +1,1342 @@
+package app
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func newTestApp(mockClient *MockGitLabClient) *App {
+	app := NewWithClient("token", "https://gitlab.com/", mockClient)
+	app.SetLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	return app
+}
+
+func TestApp_ListProjectMergeRequests(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		opts    *ListMergeRequestsOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    []MergeRequest
+		wantErr bool
+	}{
+		{
+			name: "successful list with default options",
+			opts: &ListMergeRequestsOptions{State: "opened", Limit: 100},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedOpts := &gitlab.ListProjectMergeRequestsOptions{
+					State:       gitlab.Ptr("opened"),
+					ListOptions: gitlab.ListOptions{PerPage: 100, Page: 1},
+				}
+
+				mrs.On("ListProjectMergeRequests", int64(123), expectedOpts).Return(
+					[]*gitlab.MergeRequest{
+						{
+							BasicMergeRequest: gitlab.BasicMergeRequest{
+								ID:                  1,
+								IID:                 10,
+								Title:               "Test MR",
+								Description:         "Test Description",
+								State:               "opened",
+								SourceBranch:        "feature",
+								TargetBranch:        "main",
+								Labels:              gitlab.Labels{"bug"},
+								WebURL:              "https://gitlab.com/test/project/-/merge_requests/10",
+								DetailedMergeStatus: "mergeable",
+								Draft:               false,
+								Author:              &gitlab.BasicUser{ID: 1, Username: "user1", Name: "User One"},
+								CreatedAt:           &testTime,
+								UpdatedAt:           &testTime,
+							},
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []MergeRequest{
+				{
+					ID:           1,
+					IID:          10,
+					Title:        "Test MR",
+					Description:  "Test Description",
+					State:        "opened",
+					SourceBranch: "feature",
+					TargetBranch: "main",
+					Labels:       []string{"bug"},
+					WebURL:       "https://gitlab.com/test/project/-/merge_requests/10",
+					MergeStatus:  "mergeable",
+					Draft:        false,
+					Author:       map[string]any{"id": int64(1), "username": "user1", "name": "User One"},
+					CreatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+					UpdatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+				},
+			},
+		},
+		{
+			name: "successful list with filters",
+			opts: &ListMergeRequestsOptions{State: "merged", Labels: []string{"bug"}, Author: "dev1", Search: "fix", Limit: 50},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedLabels := gitlab.LabelOptions([]string{"bug"})
+				expectedOpts := &gitlab.ListProjectMergeRequestsOptions{
+					State:          gitlab.Ptr("merged"),
+					Labels:         &expectedLabels,
+					AuthorUsername: gitlab.Ptr("dev1"),
+					Search:         gitlab.Ptr("fix"),
+					ListOptions:    gitlab.ListOptions{PerPage: 50, Page: 1},
+				}
+
+				mrs.On("ListProjectMergeRequests", int64(123), expectedOpts).Return(
+					[]*gitlab.MergeRequest{},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []MergeRequest{},
+		},
+		{
+			name: "project not found",
+			opts: nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("project not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "API error on list",
+			opts: nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedOpts := &gitlab.ListProjectMergeRequestsOptions{
+					ListOptions: gitlab.ListOptions{PerPage: 100, Page: 1},
+				}
+
+				mrs.On("ListProjectMergeRequests", int64(123), expectedOpts).Return(
+					([]*gitlab.MergeRequest)(nil), (*gitlab.Response)(nil), errors.New("API error"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty results",
+			opts: &ListMergeRequestsOptions{State: "opened", Limit: 100},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedOpts := &gitlab.ListProjectMergeRequestsOptions{
+					State:       gitlab.Ptr("opened"),
+					ListOptions: gitlab.ListOptions{PerPage: 100, Page: 1},
+				}
+
+				mrs.On("ListProjectMergeRequests", int64(123), expectedOpts).Return(
+					[]*gitlab.MergeRequest{},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []MergeRequest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.ListProjectMergeRequests("test/project", tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_CreateProjectMergeRequest(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		opts    *CreateMergeRequestOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    *MergeRequest
+		wantErr bool
+	}{
+		{
+			name: "successful create with minimal options",
+			opts: &CreateMergeRequestOptions{
+				Title:        "New MR",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+			},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedOpts := &gitlab.CreateMergeRequestOptions{
+					Title:        gitlab.Ptr("New MR"),
+					SourceBranch: gitlab.Ptr("feature"),
+					TargetBranch: gitlab.Ptr("main"),
+				}
+
+				mrs.On("CreateMergeRequest", int64(123), expectedOpts).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:           1,
+							IID:          10,
+							Title:        "New MR",
+							State:        "opened",
+							SourceBranch: "feature",
+							TargetBranch: "main",
+							Author:       &gitlab.BasicUser{ID: 1, Username: "user1", Name: "User One"},
+							CreatedAt:    &testTime,
+							UpdatedAt:    &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:           1,
+				IID:          10,
+				Title:        "New MR",
+				State:        "opened",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+				Author:       map[string]any{"id": int64(1), "username": "user1", "name": "User One"},
+				CreatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name: "successful create with all options",
+			opts: &CreateMergeRequestOptions{
+				Title:        "Full MR",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+				Description:  "Full description",
+				Labels:       []string{"bug", "urgent"},
+				AssigneeIDs:  []int64{1, 2},
+				ReviewerIDs:  []int64{3},
+			},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedLabels := gitlab.LabelOptions([]string{"bug", "urgent"})
+				expectedOpts := &gitlab.CreateMergeRequestOptions{
+					Title:        gitlab.Ptr("Full MR"),
+					SourceBranch: gitlab.Ptr("feature"),
+					TargetBranch: gitlab.Ptr("main"),
+					Description:  gitlab.Ptr("Full description"),
+					Labels:       &expectedLabels,
+					AssigneeIDs:  &[]int64{1, 2},
+					ReviewerIDs:  &[]int64{3},
+				}
+
+				mrs.On("CreateMergeRequest", int64(123), expectedOpts).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:           2,
+							IID:          11,
+							Title:        "Full MR",
+							Description:  "Full description",
+							State:        "opened",
+							SourceBranch: "feature",
+							TargetBranch: "main",
+							Labels:       gitlab.Labels{"bug", "urgent"},
+							Author:       &gitlab.BasicUser{ID: 1, Username: "user1", Name: "User One"},
+							Assignees:    []*gitlab.BasicUser{{ID: 1, Username: "a1", Name: "Assignee 1"}, {ID: 2, Username: "a2", Name: "Assignee 2"}},
+							Reviewers:    []*gitlab.BasicUser{{ID: 3, Username: "r1", Name: "Reviewer 1"}},
+							CreatedAt:    &testTime,
+							UpdatedAt:    &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:           2,
+				IID:          11,
+				Title:        "Full MR",
+				Description:  "Full description",
+				State:        "opened",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+				Labels:       []string{"bug", "urgent"},
+				Author:       map[string]any{"id": int64(1), "username": "user1", "name": "User One"},
+				Assignees:    []map[string]any{{"id": int64(1), "username": "a1", "name": "Assignee 1"}, {"id": int64(2), "username": "a2", "name": "Assignee 2"}},
+				Reviewers:    []map[string]any{{"id": int64(3), "username": "r1", "name": "Reviewer 1"}},
+				CreatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:    "nil options",
+			opts:    nil,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:    "empty title",
+			opts:    &CreateMergeRequestOptions{Title: "", SourceBranch: "feature", TargetBranch: "main"},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:    "empty source branch",
+			opts:    &CreateMergeRequestOptions{Title: "MR", SourceBranch: "", TargetBranch: "main"},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:    "empty target branch",
+			opts:    &CreateMergeRequestOptions{Title: "MR", SourceBranch: "feature", TargetBranch: ""},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name: "project not found",
+			opts: &CreateMergeRequestOptions{Title: "MR", SourceBranch: "feature", TargetBranch: "main"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "API error on create",
+			opts: &CreateMergeRequestOptions{Title: "MR", SourceBranch: "feature", TargetBranch: "main"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("CreateMergeRequest", int64(123), &gitlab.CreateMergeRequestOptions{
+					Title:        gitlab.Ptr("MR"),
+					SourceBranch: gitlab.Ptr("feature"),
+					TargetBranch: gitlab.Ptr("main"),
+				}).Return(
+					(*gitlab.MergeRequest)(nil), (*gitlab.Response)(nil), errors.New("API error"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.CreateProjectMergeRequest("test/project", tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_GetMergeRequest(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		mrIID   int64
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    *MergeRequest
+		wantErr bool
+	}{
+		{
+			name:  "successful get",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("GetMergeRequest", int64(123), int(10), (*gitlab.GetMergeRequestsOptions)(nil)).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:           1,
+							IID:          10,
+							Title:        "Test MR",
+							State:        "opened",
+							SourceBranch: "feature",
+							TargetBranch: "main",
+							CreatedAt:    &testTime,
+							UpdatedAt:    &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:           1,
+				IID:          10,
+				Title:        "Test MR",
+				State:        "opened",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+				CreatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:    "invalid IID zero",
+			mrIID:   0,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:    "invalid IID negative",
+			mrIID:   -1,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("GetMergeRequest", int64(123), int(10), (*gitlab.GetMergeRequestsOptions)(nil)).Return(
+					(*gitlab.MergeRequest)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.GetMergeRequest("test/project", tt.mrIID)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_UpdateMergeRequest(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		mrIID   int64
+		opts    *UpdateMergeRequestOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    *MergeRequest
+		wantErr bool
+	}{
+		{
+			name:  "successful partial update",
+			mrIID: 10,
+			opts:  &UpdateMergeRequestOptions{Title: "Updated Title"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedOpts := &gitlab.UpdateMergeRequestOptions{
+					Title: gitlab.Ptr("Updated Title"),
+				}
+
+				mrs.On("UpdateMergeRequest", int64(123), int(10), expectedOpts).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:           1,
+							IID:          10,
+							Title:        "Updated Title",
+							State:        "opened",
+							SourceBranch: "feature",
+							TargetBranch: "main",
+							CreatedAt:    &testTime,
+							UpdatedAt:    &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:           1,
+				IID:          10,
+				Title:        "Updated Title",
+				State:        "opened",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+				CreatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt:    testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:  "successful full update",
+			mrIID: 10,
+			opts: &UpdateMergeRequestOptions{
+				Title:       "New Title",
+				Description: "New desc",
+				State:       "closed",
+				Labels:      []string{"label1"},
+				AssigneeIDs: []int64{1},
+				ReviewerIDs: []int64{2},
+			},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				expectedLabels := gitlab.LabelOptions([]string{"label1"})
+				expectedOpts := &gitlab.UpdateMergeRequestOptions{
+					Title:       gitlab.Ptr("New Title"),
+					Description: gitlab.Ptr("New desc"),
+					StateEvent:  gitlab.Ptr("closed"),
+					Labels:      &expectedLabels,
+					AssigneeIDs: &[]int64{1},
+					ReviewerIDs: &[]int64{2},
+				}
+
+				mrs.On("UpdateMergeRequest", int64(123), int(10), expectedOpts).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:    1,
+							IID:   10,
+							Title: "New Title",
+							State: "closed",
+							Labels: gitlab.Labels{"label1"},
+							CreatedAt: &testTime,
+							UpdatedAt: &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:        1,
+				IID:       10,
+				Title:     "New Title",
+				State:     "closed",
+				Labels:    []string{"label1"},
+				CreatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:    "invalid IID",
+			mrIID:   0,
+			opts:    &UpdateMergeRequestOptions{Title: "T"},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:    "nil options",
+			mrIID:   10,
+			opts:    nil,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			opts:  &UpdateMergeRequestOptions{Title: "T"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			opts:  &UpdateMergeRequestOptions{Title: "T"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("UpdateMergeRequest", int64(123), int(10), &gitlab.UpdateMergeRequestOptions{
+					Title: gitlab.Ptr("T"),
+				}).Return(
+					(*gitlab.MergeRequest)(nil), (*gitlab.Response)(nil), errors.New("API error"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.UpdateMergeRequest("test/project", tt.mrIID, tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_MergeMergeRequest(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		mrIID   int64
+		opts    *MergeMergeRequestOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    *MergeRequest
+		wantErr bool
+	}{
+		{
+			name:  "successful merge with no options",
+			mrIID: 10,
+			opts:  nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("AcceptMergeRequest", int64(123), int(10), &gitlab.AcceptMergeRequestOptions{}).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:    1,
+							IID:   10,
+							Title: "Merged MR",
+							State: "merged",
+							CreatedAt: &testTime,
+							UpdatedAt: &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:        1,
+				IID:       10,
+				Title:     "Merged MR",
+				State:     "merged",
+				CreatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:  "successful merge with options",
+			mrIID: 10,
+			opts: &MergeMergeRequestOptions{
+				MergeCommitMessage:       "Merge commit",
+				SquashCommitMessage:      "Squash commit",
+				Squash:                   true,
+				ShouldRemoveSourceBranch: true,
+			},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("AcceptMergeRequest", int64(123), int(10), &gitlab.AcceptMergeRequestOptions{
+					MergeCommitMessage:       gitlab.Ptr("Merge commit"),
+					SquashCommitMessage:      gitlab.Ptr("Squash commit"),
+					Squash:                   gitlab.Ptr(true),
+					ShouldRemoveSourceBranch: gitlab.Ptr(true),
+				}).Return(
+					&gitlab.MergeRequest{
+						BasicMergeRequest: gitlab.BasicMergeRequest{
+							ID:    1,
+							IID:   10,
+							Title: "Merged MR",
+							State: "merged",
+							CreatedAt: &testTime,
+							UpdatedAt: &testTime,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &MergeRequest{
+				ID:        1,
+				IID:       10,
+				Title:     "Merged MR",
+				State:     "merged",
+				CreatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:    "invalid IID",
+			mrIID:   0,
+			opts:    nil,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			opts:  nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			opts:  nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("AcceptMergeRequest", int64(123), int(10), &gitlab.AcceptMergeRequestOptions{}).Return(
+					(*gitlab.MergeRequest)(nil), (*gitlab.Response)(nil), errors.New("merge failed"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.MergeMergeRequest("test/project", tt.mrIID, tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_GetMergeRequestDiff(t *testing.T) {
+	tests := []struct {
+		name    string
+		mrIID   int64
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestsService)
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "successful diff with mixed file types",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("ListMergeRequestDiffs", int64(123), int(10), (*gitlab.ListMergeRequestDiffsOptions)(nil)).Return(
+					[]*gitlab.MergeRequestDiff{
+						{
+							OldPath: "file.go",
+							NewPath: "file.go",
+							Diff:    "@@ -1,3 +1,4 @@\n package main\n+import \"fmt\"\n",
+						},
+						{
+							NewPath: "new_file.go",
+							NewFile: true,
+							Diff:    "@@ -0,0 +1,3 @@\n+package main\n+func hello() {}\n",
+						},
+						{
+							OldPath:     "old_file.go",
+							DeletedFile: true,
+							Diff:        "@@ -1,2 +0,0 @@\n-package main\n-func old() {}\n",
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: "--- a/file.go\n+++ b/file.go\n@@ -1,3 +1,4 @@\n package main\n+import \"fmt\"\n" +
+				"\n--- /dev/null\n+++ b/new_file.go\n@@ -0,0 +1,3 @@\n+package main\n+func hello() {}\n" +
+				"\n--- a/old_file.go\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-package main\n-func old() {}\n",
+		},
+		{
+			name:  "empty diffs",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("ListMergeRequestDiffs", int64(123), int(10), (*gitlab.ListMergeRequestDiffsOptions)(nil)).Return(
+					[]*gitlab.MergeRequestDiff{},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: "No diffs available for this merge request",
+		},
+		{
+			name:    "invalid IID",
+			mrIID:   0,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, mrs *MockMergeRequestsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequests").Return(mrs)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				mrs.On("ListMergeRequestDiffs", int64(123), int(10), (*gitlab.ListMergeRequestDiffsOptions)(nil)).Return(
+					([]*gitlab.MergeRequestDiff)(nil), (*gitlab.Response)(nil), errors.New("API error"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockMRs := &MockMergeRequestsService{}
+
+			tt.setup(mockClient, mockProjects, mockMRs)
+
+			app := newTestApp(mockClient)
+			result, err := app.GetMergeRequestDiff("test/project", tt.mrIID)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockMRs.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_ApproveMergeRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		mrIID   int64
+		opts    *ApproveMergeRequestOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockMergeRequestApprovalsService)
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "successful approve without SHA",
+			mrIID: 10,
+			opts:  &ApproveMergeRequestOptions{},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, approvals *MockMergeRequestApprovalsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequestApprovals").Return(approvals)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				approvals.On("ApproveMergeRequest", int64(123), int64(10), &gitlab.ApproveMergeRequestOptions{}).Return(
+					&gitlab.MergeRequestApprovals{
+						ApprovedBy:        []*gitlab.MergeRequestApproverUser{{User: &gitlab.BasicUser{ID: 1}}},
+						ApprovalsRequired: 1,
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: "Merge request 10 approved successfully. Approvals: 1/1",
+		},
+		{
+			name:  "successful approve with SHA",
+			mrIID: 10,
+			opts:  &ApproveMergeRequestOptions{SHA: "abc123"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, approvals *MockMergeRequestApprovalsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequestApprovals").Return(approvals)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				approvals.On("ApproveMergeRequest", int64(123), int64(10), &gitlab.ApproveMergeRequestOptions{
+					SHA: gitlab.Ptr("abc123"),
+				}).Return(
+					&gitlab.MergeRequestApprovals{
+						ApprovedBy:        []*gitlab.MergeRequestApproverUser{{User: &gitlab.BasicUser{ID: 1}}, {User: &gitlab.BasicUser{ID: 2}}},
+						ApprovalsRequired: 2,
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: "Merge request 10 approved successfully. Approvals: 2/2",
+		},
+		{
+			name:    "invalid IID",
+			mrIID:   0,
+			opts:    nil,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, approvals *MockMergeRequestApprovalsService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			opts:  nil,
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, approvals *MockMergeRequestApprovalsService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			opts:  &ApproveMergeRequestOptions{},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, approvals *MockMergeRequestApprovalsService) {
+				client.On("Projects").Return(projects)
+				client.On("MergeRequestApprovals").Return(approvals)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				approvals.On("ApproveMergeRequest", int64(123), int64(10), &gitlab.ApproveMergeRequestOptions{}).Return(
+					(*gitlab.MergeRequestApprovals)(nil), (*gitlab.Response)(nil), errors.New("forbidden"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockApprovals := &MockMergeRequestApprovalsService{}
+
+			tt.setup(mockClient, mockProjects, mockApprovals)
+
+			app := newTestApp(mockClient)
+			result, err := app.ApproveMergeRequest("test/project", tt.mrIID, tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockApprovals.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApp_AddMergeRequestNote(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name    string
+		mrIID   int64
+		opts    *AddMergeRequestNoteOptions
+		setup   func(*MockGitLabClient, *MockProjectsService, *MockNotesService)
+		want    *Note
+		wantErr bool
+	}{
+		{
+			name:  "successful note creation",
+			mrIID: 10,
+			opts:  &AddMergeRequestNoteOptions{Body: "LGTM!"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {
+				client.On("Projects").Return(projects)
+				client.On("Notes").Return(notes)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				notes.On("CreateMergeRequestNote", int64(123), int64(10), &gitlab.CreateMergeRequestNoteOptions{
+					Body: gitlab.Ptr("LGTM!"),
+				}).Return(
+					&gitlab.Note{
+						ID:          1,
+						Body:        "LGTM!",
+						System:      false,
+						Author:      gitlab.NoteAuthor{ID: 5, Username: "reviewer", Name: "Reviewer"},
+						NoteableID:  10,
+						NoteableIID: 10,
+						NoteableType: "MergeRequest",
+						CreatedAt:   &testTime,
+						UpdatedAt:   &testTime,
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: &Note{
+				ID:   1,
+				Body: "LGTM!",
+				Author: map[string]any{
+					"id":       int64(5),
+					"username": "reviewer",
+					"name":     "Reviewer",
+				},
+				Noteable: map[string]any{
+					"id":   int64(10),
+					"iid":  int64(10),
+					"type": "MergeRequest",
+				},
+				CreatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt: testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name:    "empty body",
+			mrIID:   10,
+			opts:    &AddMergeRequestNoteOptions{Body: ""},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {},
+			wantErr: true,
+		},
+		{
+			name:    "nil options",
+			mrIID:   10,
+			opts:    nil,
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {},
+			wantErr: true,
+		},
+		{
+			name:    "invalid IID",
+			mrIID:   0,
+			opts:    &AddMergeRequestNoteOptions{Body: "test"},
+			setup:   func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {},
+			wantErr: true,
+		},
+		{
+			name:  "project not found",
+			mrIID: 10,
+			opts:  &AddMergeRequestNoteOptions{Body: "test"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {
+				client.On("Projects").Return(projects)
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					(*gitlab.Project)(nil), (*gitlab.Response)(nil), errors.New("not found"),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "API error",
+			mrIID: 10,
+			opts:  &AddMergeRequestNoteOptions{Body: "test"},
+			setup: func(client *MockGitLabClient, projects *MockProjectsService, notes *MockNotesService) {
+				client.On("Projects").Return(projects)
+				client.On("Notes").Return(notes)
+
+				projects.On("GetProject", "test/project", (*gitlab.GetProjectOptions)(nil)).Return(
+					&gitlab.Project{ID: 123}, &gitlab.Response{}, nil,
+				)
+
+				notes.On("CreateMergeRequestNote", int64(123), int64(10), &gitlab.CreateMergeRequestNoteOptions{
+					Body: gitlab.Ptr("test"),
+				}).Return(
+					(*gitlab.Note)(nil), (*gitlab.Response)(nil), errors.New("API error"),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockProjects := &MockProjectsService{}
+			mockNotes := &MockNotesService{}
+
+			tt.setup(mockClient, mockProjects, mockNotes)
+
+			app := newTestApp(mockClient)
+			result, err := app.AddMergeRequestNote("test/project", tt.mrIID, tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, result)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockProjects.AssertExpectations(t)
+			mockNotes.AssertExpectations(t)
+		})
+	}
+}
+
+func TestConvertGitLabMergeRequest(t *testing.T) {
+	testTime := time.Now()
+
+	tests := []struct {
+		name  string
+		input *gitlab.MergeRequest
+		want  MergeRequest
+	}{
+		{
+			name: "full conversion with all fields",
+			input: &gitlab.MergeRequest{
+				BasicMergeRequest: gitlab.BasicMergeRequest{
+					ID:                  1,
+					IID:                 10,
+					Title:               "Full MR",
+					Description:         "Description",
+					State:               "opened",
+					SourceBranch:        "feature",
+					TargetBranch:        "main",
+					Labels:              gitlab.Labels{"bug", "urgent"},
+					WebURL:              "https://gitlab.com/test/-/merge_requests/10",
+					DetailedMergeStatus: "mergeable",
+					Draft:               true,
+					Author:              &gitlab.BasicUser{ID: 1, Username: "user1", Name: "User One"},
+					Assignees:           []*gitlab.BasicUser{{ID: 2, Username: "a1", Name: "Assignee"}},
+					Reviewers:           []*gitlab.BasicUser{{ID: 3, Username: "r1", Name: "Reviewer"}},
+					CreatedAt:           &testTime,
+					UpdatedAt:           &testTime,
+				},
+			},
+			want: MergeRequest{
+				ID:             1,
+				IID:            10,
+				Title:          "Full MR",
+				Description:    "Description",
+				State:          "opened",
+				SourceBranch:   "feature",
+				TargetBranch:   "main",
+				Labels:         []string{"bug", "urgent"},
+				WebURL:         "https://gitlab.com/test/-/merge_requests/10",
+				MergeStatus:    "mergeable",
+				Draft:          true,
+				WorkInProgress: true,
+				Author:         map[string]any{"id": int64(1), "username": "user1", "name": "User One"},
+				Assignees:      []map[string]any{{"id": int64(2), "username": "a1", "name": "Assignee"}},
+				Reviewers:      []map[string]any{{"id": int64(3), "username": "r1", "name": "Reviewer"}},
+				CreatedAt:      testTime.Format("2006-01-02T15:04:05Z"),
+				UpdatedAt:      testTime.Format("2006-01-02T15:04:05Z"),
+			},
+		},
+		{
+			name: "nil author and empty collections",
+			input: &gitlab.MergeRequest{
+				BasicMergeRequest: gitlab.BasicMergeRequest{
+					ID:    1,
+					IID:   10,
+					Title: "Minimal MR",
+					State: "opened",
+				},
+			},
+			want: MergeRequest{
+				ID:    1,
+				IID:   10,
+				Title: "Minimal MR",
+				State: "opened",
+			},
+		},
+		{
+			name: "nil timestamps",
+			input: &gitlab.MergeRequest{
+				BasicMergeRequest: gitlab.BasicMergeRequest{
+					ID:        1,
+					IID:       10,
+					Title:     "No Timestamps",
+					State:     "opened",
+					Author:    &gitlab.BasicUser{ID: 1, Username: "u", Name: "U"},
+					CreatedAt: nil,
+					UpdatedAt: nil,
+				},
+			},
+			want: MergeRequest{
+				ID:     1,
+				IID:    10,
+				Title:  "No Timestamps",
+				State:  "opened",
+				Author: map[string]any{"id": int64(1), "username": "u", "name": "U"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertGitLabMergeRequest(tt.input)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/internal/app/mocks.go
+++ b/internal/app/mocks.go
@@ -82,6 +82,18 @@ func (m *MockGitLabClient) GroupLabels() GroupLabelsService {
 	return result
 }
 
+func (m *MockGitLabClient) MergeRequests() MergeRequestsService {
+	args := m.Called()
+	result, _ := args.Get(0).(MergeRequestsService)
+	return result
+}
+
+func (m *MockGitLabClient) MergeRequestApprovals() MergeRequestApprovalsService {
+	args := m.Called()
+	result, _ := args.Get(0).(MergeRequestApprovalsService)
+	return result
+}
+
 // MockProjectsService is a mock implementation of ProjectsService.
 type MockProjectsService struct {
 	mock.Mock
@@ -233,6 +245,17 @@ func (m *MockNotesService) CreateIssueNote(
 	return note, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }
 
+func (m *MockNotesService) CreateMergeRequestNote(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.CreateMergeRequestNoteOptions,
+) (*gitlab.Note, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	note, _ := args.Get(0).(*gitlab.Note)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return note, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
 // MockGroupsService is a mock implementation of GroupsService.
 type MockGroupsService struct {
 	mock.Mock
@@ -351,4 +374,100 @@ func (m *MockJobsService) GetTraceFile(
 	reader, _ := args.Get(0).(io.Reader)
 	response, _ := args.Get(1).(*gitlab.Response)
 	return reader, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+// MockMergeRequestsService is a mock implementation of MergeRequestsService.
+type MockMergeRequestsService struct {
+	mock.Mock
+}
+
+func (m *MockMergeRequestsService) ListProjectMergeRequests(
+	pid any,
+	opt *gitlab.ListProjectMergeRequestsOptions,
+) ([]*gitlab.MergeRequest, *gitlab.Response, error) {
+	args := m.Called(pid, opt)
+	mrs, _ := args.Get(0).([]*gitlab.MergeRequest)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return mrs, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) CreateMergeRequest(
+	pid any,
+	opt *gitlab.CreateMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	args := m.Called(pid, opt)
+	mr, _ := args.Get(0).(*gitlab.MergeRequest)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return mr, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) GetMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.GetMergeRequestsOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	mr, _ := args.Get(0).(*gitlab.MergeRequest)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return mr, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) UpdateMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.UpdateMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	mr, _ := args.Get(0).(*gitlab.MergeRequest)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return mr, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) AcceptMergeRequest(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.AcceptMergeRequestOptions,
+) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	mr, _ := args.Get(0).(*gitlab.MergeRequest)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return mr, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) GetMergeRequestDiffVersions(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.GetMergeRequestDiffVersionsOptions,
+) ([]*gitlab.MergeRequestDiffVersion, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	diffs, _ := args.Get(0).([]*gitlab.MergeRequestDiffVersion)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return diffs, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+func (m *MockMergeRequestsService) ListMergeRequestDiffs(
+	pid any,
+	mergeRequest int,
+	opt *gitlab.ListMergeRequestDiffsOptions,
+) ([]*gitlab.MergeRequestDiff, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	diffs, _ := args.Get(0).([]*gitlab.MergeRequestDiff)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return diffs, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
+// MockMergeRequestApprovalsService is a mock implementation of MergeRequestApprovalsService.
+type MockMergeRequestApprovalsService struct {
+	mock.Mock
+}
+
+func (m *MockMergeRequestApprovalsService) ApproveMergeRequest(
+	pid any,
+	mergeRequest int64,
+	opt *gitlab.ApproveMergeRequestOptions,
+) (*gitlab.MergeRequestApprovals, *gitlab.Response, error) {
+	args := m.Called(pid, mergeRequest, opt)
+	approvals, _ := args.Get(0).(*gitlab.MergeRequestApprovals)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return approvals, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type ToolCategoryFlags struct {
 	ProjectMetadata bool // Project metadata tools
 	Epics           bool // Epic management tools (Premium/Ultimate tier)
 	Pipelines       bool // CI/CD pipeline tools
+	MergeRequests   bool // Merge request management tools
 }
 
 // Error variables for static errors.
@@ -1549,6 +1550,7 @@ func handleCommandLineFlags() *ToolCategoryFlags {
 		noProjectMetadata = flag.Bool("no-project-metadata", false, "Disable project metadata tools")
 		noEpics           = flag.Bool("no-epics", false, "Disable epic management tools")
 		noPipelines       = flag.Bool("no-pipelines", false, "Disable CI/CD pipeline tools")
+		noMergeRequests   = flag.Bool("no-merge-requests", false, "Disable merge request management tools")
 	)
 
 	flag.Parse()
@@ -1572,6 +1574,7 @@ func handleCommandLineFlags() *ToolCategoryFlags {
 		ProjectMetadata: !*noProjectMetadata,
 		Epics:           !*noEpics,
 		Pipelines:       !*noPipelines,
+		MergeRequests:   !*noMergeRequests,
 	}
 }
 
@@ -1843,6 +1846,12 @@ func logEnabledCategories(debugLogger *slog.Logger, flags *ToolCategoryFlags) {
 		disabled = append(disabled, "pipelines")
 	}
 
+	if flags.MergeRequests {
+		enabled = append(enabled, "merge-requests")
+	} else {
+		disabled = append(disabled, "merge-requests")
+	}
+
 	debugLogger.Info("Tool categories configuration",
 		"enabled", strings.Join(enabled, ", "),
 		"disabled", strings.Join(disabled, ", "),
@@ -1891,6 +1900,18 @@ func registerAllTools(s *server.MCPServer, appInstance *app.App, debugLogger *sl
 		setupListPipelineJobsTool(s, appInstance, debugLogger)
 		setupGetJobLogTool(s, appInstance, debugLogger)
 		setupDownloadJobTraceTool(s, appInstance, debugLogger)
+	}
+
+	// Merge Requests category (8 tools)
+	if flags.MergeRequests {
+		setupListMergeRequestsTool(s, appInstance, debugLogger)
+		setupCreateMergeRequestTool(s, appInstance, debugLogger)
+		setupGetMergeRequestTool(s, appInstance, debugLogger)
+		setupUpdateMergeRequestTool(s, appInstance, debugLogger)
+		setupMergeMergeRequestTool(s, appInstance, debugLogger)
+		setupGetMergeRequestDiffTool(s, appInstance, debugLogger)
+		setupApproveMergeRequestTool(s, appInstance, debugLogger)
+		setupAddMergeRequestNoteTool(s, appInstance, debugLogger)
 	}
 }
 

--- a/merge_request_tools.go
+++ b/merge_request_tools.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/sgaunet/gitlab-mcp/internal/app"
+)
+
+var (
+	errProjectPathRequired  = errors.New("project_path must be a non-empty string")
+	errTitleRequired        = errors.New("title must be a non-empty string")
+	errSourceBranchRequired = errors.New("source_branch must be a non-empty string")
+	errTargetBranchRequired = errors.New("target_branch must be a non-empty string")
+)
+
+// parseLabels extracts labels from interface array.
+func parseLabels(labelsInterface any) []string {
+	labels := make([]string, 0)
+	if arr, ok := labelsInterface.([]any); ok {
+		for _, label := range arr {
+			if labelStr, ok := label.(string); ok {
+				labels = append(labels, labelStr)
+			}
+		}
+	}
+	return labels
+}
+
+// parseIDArray extracts int64 IDs from interface array.
+func parseIDArray(idsInterface any) []int64 {
+	ids := make([]int64, 0)
+	if arr, ok := idsInterface.([]any); ok {
+		for _, id := range arr {
+			if idFloat, ok := id.(float64); ok {
+				ids = append(ids, int64(idFloat))
+			}
+		}
+	}
+	return ids
+}
+
+// parseListMROptions extracts list merge request options from arguments.
+func parseListMROptions(args map[string]any) *app.ListMergeRequestsOptions {
+	opts := &app.ListMergeRequestsOptions{State: "opened", Limit: defaultLimit}
+
+	if state, ok := args["state"].(string); ok && state != "" {
+		opts.State = state
+	}
+	if labelsInterface, ok := args["labels"]; ok {
+		opts.Labels = parseLabels(labelsInterface)
+	}
+	if author, ok := args["author"].(string); ok && author != "" {
+		opts.Author = author
+	}
+	if search, ok := args["search"].(string); ok && search != "" {
+		opts.Search = search
+	}
+	if limitFloat, ok := args["limit"].(float64); ok {
+		opts.Limit = int64(limitFloat)
+	}
+
+	return opts
+}
+
+// parseUpdateMROptions extracts update merge request options from arguments.
+func parseUpdateMROptions(args map[string]any) *app.UpdateMergeRequestOptions {
+	opts := &app.UpdateMergeRequestOptions{}
+
+	if title, ok := args["title"].(string); ok && title != "" {
+		opts.Title = title
+	}
+	if desc, ok := args["description"].(string); ok {
+		opts.Description = desc
+	}
+	if state, ok := args["state"].(string); ok && state != "" {
+		opts.State = state
+	}
+	if labelsInterface, ok := args["labels"]; ok {
+		opts.Labels = parseLabels(labelsInterface)
+	}
+	if assigneeIDs, ok := args["assignee_ids"]; ok {
+		opts.AssigneeIDs = parseIDArray(assigneeIDs)
+	}
+	if reviewerIDs, ok := args["reviewer_ids"]; ok {
+		opts.ReviewerIDs = parseIDArray(reviewerIDs)
+	}
+
+	return opts
+}
+
+// setupListMergeRequestsTool creates and registers the list_merge_requests tool.
+func setupListMergeRequestsTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
+	tool := mcp.NewTool("list_merge_requests",
+		mcp.WithDescription("List merge requests for a GitLab project by project path with filtering options"),
+		mcp.WithString("project_path",
+			mcp.Required(),
+			mcp.Description("GitLab project path including all namespaces"),
+		),
+		mcp.WithString("state",
+			mcp.Description("Filter by state: opened, closed, locked, merged (default: opened)"),
+		),
+		mcp.WithArray("labels",
+			mcp.Description("Array of labels to filter by"),
+		),
+		mcp.WithString("author",
+			mcp.Description("Filter by author username"),
+		),
+		mcp.WithString("search",
+			mcp.Description("Search in title and description"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of results (default: 100, max: 100)"),
+		),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		debugLogger.Debug("Received list_merge_requests tool request", "args", args)
+
+		projectPath, ok := args["project_path"].(string)
+		if !ok || projectPath == "" {
+			return mcp.NewToolResultError("project_path must be a non-empty string"), nil
+		}
+
+		opts := parseListMROptions(args)
+		mrs, err := appInstance.ListProjectMergeRequests(projectPath, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to list merge requests: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(mrs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merge requests: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}
+
+// extractRequiredString validates and extracts a required string argument.
+func extractRequiredString(args map[string]any, key string, errVal error) (string, error) {
+	val, ok := args[key].(string)
+	if !ok || val == "" {
+		return "", errVal
+	}
+	return val, nil
+}
+
+// extractCreateMRArgs validates and extracts arguments for creating a merge request.
+func extractCreateMRArgs(args map[string]any) (string, *app.CreateMergeRequestOptions, error) {
+	projectPath, err := extractRequiredString(args, "project_path", errProjectPathRequired)
+	if err != nil {
+		return "", nil, err
+	}
+
+	title, err := extractRequiredString(args, "title", errTitleRequired)
+	if err != nil {
+		return "", nil, err
+	}
+
+	sourceBranch, err := extractRequiredString(args, "source_branch", errSourceBranchRequired)
+	if err != nil {
+		return "", nil, err
+	}
+
+	targetBranch, err := extractRequiredString(args, "target_branch", errTargetBranchRequired)
+	if err != nil {
+		return "", nil, err
+	}
+
+	opts := &app.CreateMergeRequestOptions{
+		Title:        title,
+		SourceBranch: sourceBranch,
+		TargetBranch: targetBranch,
+	}
+
+	if desc, ok := args["description"].(string); ok {
+		opts.Description = desc
+	}
+	if labelsInterface, ok := args["labels"]; ok {
+		opts.Labels = parseLabels(labelsInterface)
+	}
+	if assigneeIDs, ok := args["assignee_ids"]; ok {
+		opts.AssigneeIDs = parseIDArray(assigneeIDs)
+	}
+	if reviewerIDs, ok := args["reviewer_ids"]; ok {
+		opts.ReviewerIDs = parseIDArray(reviewerIDs)
+	}
+
+	return projectPath, opts, nil
+}
+
+// setupCreateMergeRequestTool creates and registers the create_merge_request tool.
+func setupCreateMergeRequestTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
+	tool := mcp.NewTool("create_merge_request",
+		mcp.WithDescription("Create a new merge request in a GitLab project"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Merge request title")),
+		mcp.WithString("source_branch", mcp.Required(), mcp.Description("Source branch name")),
+		mcp.WithString("target_branch", mcp.Required(), mcp.Description("Target branch name")),
+		mcp.WithString("description", mcp.Description("Merge request description")),
+		mcp.WithArray("labels", mcp.Description("Array of labels")),
+		mcp.WithArray("assignee_ids", mcp.Description("Array of assignee user IDs")),
+		mcp.WithArray("reviewer_ids", mcp.Description("Array of reviewer user IDs")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		debugLogger.Debug("Received create_merge_request tool request", "args", args)
+
+		projectPath, opts, err := extractCreateMRArgs(args)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		mr, err := appInstance.CreateProjectMergeRequest(projectPath, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to create merge request: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(mr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merge request: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}
+
+// setupGetMergeRequestTool creates and registers the get_merge_request tool.
+func setupGetMergeRequestTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("get_merge_request",
+		mcp.WithDescription("Get details of a specific merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request internal ID (IID)")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+
+		mr, err := appInstance.GetMergeRequest(projectPath, mrIID)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to get merge request: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(mr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merge request: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}
+
+// setupUpdateMergeRequestTool creates and registers the update_merge_request tool.
+func setupUpdateMergeRequestTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("update_merge_request",
+		mcp.WithDescription("Update an existing merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request IID to update")),
+		mcp.WithString("title", mcp.Description("Updated title")),
+		mcp.WithString("description", mcp.Description("Updated description")),
+		mcp.WithString("state", mcp.Description("State: opened, closed")),
+		mcp.WithArray("labels", mcp.Description("Array of labels")),
+		mcp.WithArray("assignee_ids", mcp.Description("Array of assignee user IDs")),
+		mcp.WithArray("reviewer_ids", mcp.Description("Array of reviewer user IDs")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+
+		opts := parseUpdateMROptions(args)
+		mr, err := appInstance.UpdateMergeRequest(projectPath, mrIID, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to update merge request: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(mr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merge request: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}
+
+// setupMergeMergeRequestTool creates and registers the merge_merge_request tool.
+func setupMergeMergeRequestTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("merge_merge_request",
+		mcp.WithDescription("Merge an approved merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request IID to merge")),
+		mcp.WithString("merge_commit_message", mcp.Description("Custom merge commit message")),
+		mcp.WithString("squash_commit_message", mcp.Description("Custom squash commit message")),
+		mcp.WithBoolean("squash", mcp.Description("Squash commits before merging")),
+		mcp.WithBoolean("should_remove_source_branch", mcp.Description("Remove source branch after merge")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+
+		opts := &app.MergeMergeRequestOptions{}
+		if msg, ok := args["merge_commit_message"].(string); ok && msg != "" {
+			opts.MergeCommitMessage = msg
+		}
+		if msg, ok := args["squash_commit_message"].(string); ok && msg != "" {
+			opts.SquashCommitMessage = msg
+		}
+		if squash, ok := args["squash"].(bool); ok {
+			opts.Squash = squash
+		}
+		if remove, ok := args["should_remove_source_branch"].(bool); ok {
+			opts.ShouldRemoveSourceBranch = remove
+		}
+
+		mr, err := appInstance.MergeMergeRequest(projectPath, mrIID, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to merge request: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(mr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal merge request: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}
+
+// setupGetMergeRequestDiffTool creates and registers the get_merge_request_diff tool.
+func setupGetMergeRequestDiffTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("get_merge_request_diff",
+		mcp.WithDescription("Get the diff for a merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request IID")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+
+		diff, err := appInstance.GetMergeRequestDiff(projectPath, mrIID)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to get merge request diff: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText(diff), nil
+	})
+}
+
+// setupApproveMergeRequestTool creates and registers the approve_merge_request tool.
+func setupApproveMergeRequestTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("approve_merge_request",
+		mcp.WithDescription("Approve a merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request IID to approve")),
+		mcp.WithString("sha", mcp.Description("Optional: specific commit SHA to approve")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+
+		opts := &app.ApproveMergeRequestOptions{}
+		if sha, ok := args["sha"].(string); ok && sha != "" {
+			opts.SHA = sha
+		}
+
+		result, err := appInstance.ApproveMergeRequest(projectPath, mrIID, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to approve merge request: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText(result), nil
+	})
+}
+
+// setupAddMergeRequestNoteTool creates and registers the add_merge_request_note tool.
+func setupAddMergeRequestNoteTool(s *server.MCPServer, appInstance *app.App, _ *slog.Logger) {
+	tool := mcp.NewTool("add_merge_request_note",
+		mcp.WithDescription("Add a comment/note to a merge request"),
+		mcp.WithString("project_path", mcp.Required(), mcp.Description("GitLab project path")),
+		mcp.WithNumber("mr_iid", mcp.Required(), mcp.Description("Merge request IID")),
+		mcp.WithString("body", mcp.Required(), mcp.Description("Comment body text")),
+	)
+
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		projectPath, _ := args["project_path"].(string)
+		mrIIDFloat, _ := args["mr_iid"].(float64)
+		mrIID := int64(mrIIDFloat)
+		body, _ := args["body"].(string)
+
+		opts := &app.AddMergeRequestNoteOptions{Body: body}
+		note, err := appInstance.AddMergeRequestNote(projectPath, mrIID, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to add merge request note: %v", err)), nil
+		}
+
+		jsonData, err := json.Marshal(note)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal note: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
+}


### PR DESCRIPTION
- Add 8 MCP tools: list, create, get, update, merge, diff, approve, note
- Add MergeRequestsService and MergeRequestApprovalsService interfaces
- Add client wrappers with BasicMergeRequest direct conversion (no N+1)
- Add GetMergeRequestDiff using ListMergeRequestDiffs for actual code diffs
- Add input validation for create MR handler required fields
- Add comprehensive unit tests (42 test cases, coverage 72.7% → 83.1%)
- Add --no-merge-requests CLI flag for token optimization
- Update CLAUDE.md with tools, flags, examples, and test coverage

Refs #95