### PR TITLE
feat(projects): add list_group_projects tool for group discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This is a Model Context Protocol (MCP) server that provides GitLab integration t
 - `update_issues`: Updates existing issues (title, description, state, labels (validated), assignees)
 - `list_labels`: Lists project labels with optional filtering and counts
 - `add_issue_note`: Adds notes/comments to existing issues
+- `list_group_projects`: Lists all projects of a GitLab group recursively (all subgroups included) with id, name, namespaced path, description and topics
 - `get_project_description`: Gets the current description of a GitLab project
 - `update_project_description`: Updates the description of a GitLab project
 - `get_project_topics`: Gets the current topics/tags of a GitLab project
@@ -104,6 +105,27 @@ When group issues are included, issues that belong to the current project are de
 **Graceful fallback:**
 
 If fetching group issues fails (due to permissions or other errors), the tool automatically falls back to returning only project issues, ensuring the request always succeeds when project access is available.
+
+**Discovering projects in a group:**
+
+The `list_group_projects` tool enumerates every project under a group, recursing through all
+subgroups server-side via GitLab's `include_subgroups` parameter. The returned `path` is the full
+namespaced path, so it can be fed directly to any other tool as `project_path`.
+
+```
+List all projects of the myorg group
+```
+
+```
+List only the projects directly owned by myorg (include_subgroups=false)
+```
+
+```
+List projects of myorg tagged with topic "golang"
+```
+
+Results are auto-paginated: `limit` defaults to 100 and is capped at 1000, with the server fetching
+as many API pages as needed. Archived projects are excluded unless `include_archived=true`.
 
 **Managing project descriptions:**
 ```
@@ -242,6 +264,7 @@ The server supports CLI flags to disable tool categories, reducing token consump
 - `--no-epics` - Disable epic management tools (3 tools)
 - `--no-pipelines` - Disable CI/CD pipeline tools (4 tools)
 - `--no-merge-requests` - Disable merge request management tools (8 tools)
+- `--no-projects` - Disable group project discovery tools (1 tool)
 
 ### Usage Examples
 
@@ -419,6 +442,7 @@ The server uses the official GitLab Go client to interact with GitLab's REST API
 - **Issue Updates**: `/projects/:id/issues/:issue_iid` endpoint for updating existing issues
 - **Notes Creation**: `/projects/:id/issues/:issue_iid/notes` endpoint for adding notes/comments to issues
 - **Labels List**: `/projects/:id/labels` endpoint for label retrieval
+- **Group Projects List**: `/groups/:id/projects?include_subgroups=true` endpoint for recursive project discovery (auto-paginated)
 - **Filtering**: Supports state filtering, label filtering, search, and pagination
 - **Deduplication**: Group issues are filtered to exclude duplicates from the current project
 - **Merge Requests List**: `/projects/:id/merge_requests` endpoint for MR retrieval
@@ -449,6 +473,7 @@ Unit tests provide comprehensive coverage of all functionality:
 - `UpdateProjectIssue`: Issue updates with partial/full updates, state changes, and validation
 - `AddIssueNote`: Note creation with body validation, project resolution, and API error handling
 - `ListProjectLabels`: Label retrieval with optional filtering, search, and counts
+- `ListGroupProjects`: Recursive group project discovery with multi-page pagination, limit clamping, subgroup/archived/search/topic filters, and nil-response safety
 - `GetLatestPipeline`: Pipeline retrieval with ref filtering and error scenarios
 - `ListPipelineJobs`: Job listing with pipeline ID resolution, status/stage filtering, and comprehensive error handling
 - `ListProjectMergeRequests`: MR retrieval with state filtering, label/author/search filters, and error scenarios
@@ -461,7 +486,7 @@ Unit tests provide comprehensive coverage of all functionality:
 - `AddMergeRequestNote`: MR note creation with body validation and error handling
 - Edge cases: nil parameters, empty values, API errors, project not found, invalid IIDs
 
-All tests run without external dependencies using mocked GitLab client interfaces. Current test coverage is **83.1%**.
+All tests run without external dependencies using mocked GitLab client interfaces. Current test coverage is **83.6%**.
 
 ### Group Issues Integration
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Model Context Protocol (MCP) server that provides GitLab integration tools for
 - **Issue Management**: List, create, update issues, and add comments
 - **Label Management**: List and manage project labels with filtering
 - **Project Management**: View and update project descriptions and topics
+- **Project Discovery**: List all projects of a group recursively, including every subgroup
 - **Epic Management**: List and create epics (Premium/Ultimate tier)
 - **CI/CD Integration**: Monitor pipelines, view job logs, and download traces
 - **Direct Project Access**: Use project paths (namespace/project-name) without ID resolution
@@ -72,7 +73,7 @@ gitlab-mcp --no-issues --no-labels --no-project-metadata --no-epics
 gitlab-mcp --no-project-metadata --no-epics --no-pipelines
 ```
 
-Available flags: `--no-issues`, `--no-labels`, `--no-project-metadata`, `--no-epics`, `--no-pipelines`
+Available flags: `--no-issues`, `--no-labels`, `--no-project-metadata`, `--no-epics`, `--no-pipelines`, `--no-merge-requests`, `--no-projects`
 
 [Complete CLI configuration →](docs/SETUP.md#cli-flags)
 
@@ -88,6 +89,10 @@ Create an issue with title "Bug fix needed" for project myorg/myproject
 
 ```
 Get the latest pipeline for myorg/myproject
+```
+
+```
+List all projects of the myorg group
 ```
 
 ## Documentation
@@ -108,6 +113,7 @@ Get the latest pipeline for myorg/myproject
 | `update_issues` | Update issue title, description, state, labels |
 | `add_issue_note` | Add comments to issues |
 | `list_labels` | List project labels with optional filtering |
+| `list_group_projects` | List all projects of a group, subgroups included |
 | `get_project_description` | Get project description |
 | `update_project_description` | Update project description |
 | `get_project_topics` | Get project topics/tags |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -269,6 +269,8 @@ All tools are enabled by default. Use these flags to opt-out of specific categor
 - `--no-project-metadata` - Disable project metadata tools (4 tools)
 - `--no-epics` - Disable epic management tools (3 tools)
 - `--no-pipelines` - Disable CI/CD pipeline tools (4 tools)
+- `--no-merge-requests` - Disable merge request management tools (8 tools)
+- `--no-projects` - Disable group project discovery tools (1 tool)
 
 ### Token Savings
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -14,6 +14,7 @@ Complete reference for all GitLab MCP tools available in Claude Code.
 - [Label Management](#label-management)
   - [list_labels](#list_labels)
 - [Project Management](#project-management)
+  - [list_group_projects](#list_group_projects)
   - [get_project_description](#get_project_description)
   - [update_project_description](#update_project_description)
   - [get_project_topics](#get_project_topics)
@@ -365,6 +366,83 @@ Returns a JSON array of label objects:
 ---
 
 ## Project Management
+
+### list_group_projects
+
+Lists all projects of a GitLab group, recursively including every subgroup at any depth. Useful for
+discovering which projects exist before using the other tools — the returned `path` can be passed
+directly as `project_path` to any of them.
+
+Recursion is performed by GitLab itself (`include_subgroups`), so nested groups of any depth are
+covered by a single call. Results spanning several API pages are fetched automatically.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `group_path` | string | Yes | - | GitLab group path including all parent namespaces (e.g. `mygroup` or `company/department/team`) |
+| `include_subgroups` | boolean | No | `true` | Recurse into all descendant subgroups. Set to `false` to list only projects directly owned by the group |
+| `include_archived` | boolean | No | `false` | Include archived projects |
+| `search` | string | No | - | Filter projects by name or path substring |
+| `topic` | string | No | - | Filter projects by topic/tag |
+| `limit` | number | No | `100` | Maximum number of projects to return (max: 1000) |
+
+#### Examples
+
+```
+List all projects of the myorg group
+```
+
+```
+List all projects in myorg/platform including subgroups
+```
+
+```
+List only the projects directly owned by myorg, without subgroups
+```
+
+```
+List all projects of myorg tagged with the golang topic
+```
+
+```
+List up to 500 projects of myorg, including archived ones
+```
+
+#### Response Format
+
+```json
+[
+  {
+    "id": 12345,
+    "name": "payment-service",
+    "path": "myorg/backend/payment-service",
+    "description": "Payment gateway integration",
+    "topics": ["golang", "api", "payments"],
+    "web_url": "https://gitlab.com/myorg/backend/payment-service",
+    "archived": false
+  },
+  {
+    "id": 12346,
+    "name": "web-frontend",
+    "path": "myorg/frontend/web-frontend",
+    "description": "Customer-facing web application",
+    "topics": ["typescript", "react"],
+    "web_url": "https://gitlab.com/myorg/frontend/web-frontend",
+    "archived": false
+  }
+]
+```
+
+#### Notes
+
+- `path` is the full namespaced path (`path_with_namespace`), which is exactly what every other tool
+  in this server expects as `project_path`.
+- The group path must be a **group**, not a user namespace. Personal namespaces return `404 Not Found`
+  because GitLab exposes no group projects endpoint for them.
+- Requires at least the `read_api` token scope; only projects visible to the token are returned.
+
+---
 
 ### get_project_description
 

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -255,6 +255,17 @@ func (g *GroupsServiceWrapper) GetGroup(
 	return group, resp, nil
 }
 
+func (g *GroupsServiceWrapper) ListGroupProjects(
+	gid any,
+	opt *gitlab.ListGroupProjectsOptions,
+) ([]*gitlab.Project, *gitlab.Response, error) {
+	projects, resp, err := g.service.ListGroupProjects(gid, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gitlab client: %w", err)
+	}
+	return projects, resp, nil
+}
+
 // GroupLabelsServiceWrapper wraps the real GroupLabels service.
 type GroupLabelsServiceWrapper struct {
 	service gitlab.GroupLabelsServiceInterface

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -15,6 +15,10 @@ type ProjectsService interface {
 // GroupsService interface for GitLab Groups operations.
 type GroupsService interface {
 	GetGroup(gid any, opt *gitlab.GetGroupOptions) (*gitlab.Group, *gitlab.Response, error)
+	ListGroupProjects(
+		gid any,
+		opt *gitlab.ListGroupProjectsOptions,
+	) ([]*gitlab.Project, *gitlab.Response, error)
 }
 
 // IssuesService interface for GitLab Issues operations.

--- a/internal/app/mocks.go
+++ b/internal/app/mocks.go
@@ -271,6 +271,16 @@ func (m *MockGroupsService) GetGroup(
 	return group, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
 }
 
+func (m *MockGroupsService) ListGroupProjects(
+	gid any,
+	opt *gitlab.ListGroupProjectsOptions,
+) ([]*gitlab.Project, *gitlab.Response, error) {
+	args := m.Called(gid, opt)
+	projects, _ := args.Get(0).([]*gitlab.Project)
+	response, _ := args.Get(1).(*gitlab.Response)
+	return projects, response, args.Error(errorArgIndex) //nolint:wrapcheck // Mock should pass through errors
+}
+
 // MockEpicsService is a mock implementation of EpicsService.
 type MockEpicsService struct {
 	mock.Mock

--- a/internal/app/projects.go
+++ b/internal/app/projects.go
@@ -1,0 +1,149 @@
+package app
+
+import (
+	"fmt"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+const (
+	maxProjectsPerPage = 100  // GitLab API page-size ceiling.
+	maxProjectsTotal   = 1000 // Hard cap on the number of projects returned in one call.
+
+	// Ordering used for group project listings, for deterministic pagination.
+	projectsOrderBy = "path"
+	projectsSort    = "asc"
+)
+
+// ListGroupProjectsOptions holds the filters accepted by ListGroupProjects.
+type ListGroupProjectsOptions struct {
+	IncludeSubgroups bool   // Recurse into every descendant subgroup.
+	IncludeArchived  bool   // Include archived projects in the results.
+	Search           string // Filter by name/path substring.
+	Topic            string // Filter by topic/tag.
+	Limit            int64  // Maximum number of projects to return.
+}
+
+// GroupProject represents a project discovered under a group.
+type GroupProject struct {
+	ID          int64    `json:"id"`
+	Name        string   `json:"name"`
+	Path        string   `json:"path"`
+	Description string   `json:"description"`
+	Topics      []string `json:"topics"`
+	WebURL      string   `json:"web_url"`
+	Archived    bool     `json:"archived"`
+}
+
+// normalizeListGroupProjectsOptions returns a copy of opts with defaults applied.
+// The caller's struct is never modified.
+func normalizeListGroupProjectsOptions(opts *ListGroupProjectsOptions) ListGroupProjectsOptions {
+	if opts == nil {
+		return ListGroupProjectsOptions{
+			IncludeSubgroups: true,
+			Limit:            maxProjectsPerPage,
+		}
+	}
+
+	normalized := *opts
+	if normalized.Limit <= 0 {
+		normalized.Limit = maxProjectsPerPage
+	}
+	if normalized.Limit > maxProjectsTotal {
+		normalized.Limit = maxProjectsTotal
+	}
+
+	return normalized
+}
+
+// buildListGroupProjectsOptions converts our options to GitLab API options.
+func buildListGroupProjectsOptions(opts ListGroupProjectsOptions) *gitlab.ListGroupProjectsOptions {
+	listOpts := &gitlab.ListGroupProjectsOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: min(opts.Limit, maxProjectsPerPage),
+			Page:    1,
+		},
+		IncludeSubGroups: new(opts.IncludeSubgroups),
+		OrderBy:          new(projectsOrderBy),
+		Sort:             new(projectsSort),
+	}
+
+	// Leaving Archived unset returns both archived and active projects, which is
+	// what include_archived=true means. Setting it to false excludes archived ones.
+	if !opts.IncludeArchived {
+		listOpts.Archived = new(false)
+	}
+
+	if opts.Search != "" {
+		listOpts.Search = new(opts.Search)
+	}
+	if opts.Topic != "" {
+		listOpts.Topic = new(opts.Topic)
+	}
+
+	return listOpts
+}
+
+// convertGitLabProject converts a GitLab project to our GroupProject representation.
+func convertGitLabProject(project *gitlab.Project) GroupProject {
+	return GroupProject{
+		ID:          project.ID,
+		Name:        project.Name,
+		Path:        project.PathWithNamespace,
+		Description: project.Description,
+		Topics:      project.Topics,
+		WebURL:      project.WebURL,
+		Archived:    project.Archived,
+	}
+}
+
+// hasMoreProjectPages reports whether another page should be requested.
+func hasMoreProjectPages(batchSize int, resp *gitlab.Response, collected, limit int64) bool {
+	if batchSize == 0 || collected >= limit {
+		return false
+	}
+	// resp is nil when the underlying client wrapper drops it; stop rather than panic.
+	return resp != nil && resp.NextPage > 0
+}
+
+// ListGroupProjects lists all projects of a GitLab group, recursing through subgroups by default.
+// The group path is passed directly to the API, so no group ID resolution is required.
+func (a *App) ListGroupProjects(groupPath string, opts *ListGroupProjectsOptions) ([]GroupProject, error) {
+	a.logger.Debug("Listing projects for group", "group_path", groupPath, "options", opts)
+
+	if groupPath == "" {
+		return nil, ErrGroupPathRequired
+	}
+
+	normalized := normalizeListGroupProjectsOptions(opts)
+	listOpts := buildListGroupProjectsOptions(normalized)
+
+	result := make([]GroupProject, 0, normalized.Limit)
+	for {
+		projects, resp, err := a.client.Groups().ListGroupProjects(groupPath, listOpts)
+		if err != nil {
+			a.logger.Error("Failed to list group projects", "error", err, "group_path", groupPath)
+			return nil, fmt.Errorf("failed to list projects for group %s: %w", groupPath, err)
+		}
+
+		for _, project := range projects {
+			result = append(result, convertGitLabProject(project))
+		}
+
+		if !hasMoreProjectPages(len(projects), resp, int64(len(result)), normalized.Limit) {
+			break
+		}
+		listOpts.Page = resp.NextPage
+	}
+
+	if int64(len(result)) > normalized.Limit {
+		result = result[:normalized.Limit]
+	}
+
+	a.logger.Info("Successfully retrieved group projects",
+		"count", len(result),
+		"group_path", groupPath,
+		"include_subgroups", normalized.IncludeSubgroups)
+
+	return result, nil
+}

--- a/internal/app/projects_test.go
+++ b/internal/app/projects_test.go
@@ -1,0 +1,361 @@
+package app
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// newTestAppWithGroups builds an App wired to a mock Groups service.
+func newTestAppWithGroups(mockClient *MockGitLabClient) *App {
+	app := NewWithClient("token", "https://gitlab.com/", mockClient)
+	app.SetLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	return app
+}
+
+// expectedProjectOpts builds the GitLab options the app is expected to send.
+func expectedProjectOpts(page, perPage int64, subgroups bool) *gitlab.ListGroupProjectsOptions {
+	opts := &gitlab.ListGroupProjectsOptions{
+		ListOptions:      gitlab.ListOptions{PerPage: perPage, Page: page},
+		IncludeSubGroups: new(subgroups),
+		Archived:         new(false),
+		OrderBy:          new(projectsOrderBy),
+		Sort:             new(projectsSort),
+	}
+	return opts
+}
+
+// TestNormalizeListGroupProjectsOptions verifies defaults and clamping, and that the
+// caller's options struct is never mutated.
+func TestNormalizeListGroupProjectsOptions(t *testing.T) {
+	t.Run("nil options get defaults", func(t *testing.T) {
+		got := normalizeListGroupProjectsOptions(nil)
+		assert.True(t, got.IncludeSubgroups)
+		assert.Equal(t, int64(maxProjectsPerPage), got.Limit)
+		assert.False(t, got.IncludeArchived)
+	})
+
+	t.Run("zero limit gets default", func(t *testing.T) {
+		got := normalizeListGroupProjectsOptions(&ListGroupProjectsOptions{IncludeSubgroups: true})
+		assert.Equal(t, int64(maxProjectsPerPage), got.Limit)
+	})
+
+	t.Run("excessive limit is clamped", func(t *testing.T) {
+		got := normalizeListGroupProjectsOptions(&ListGroupProjectsOptions{Limit: 99999})
+		assert.Equal(t, int64(maxProjectsTotal), got.Limit)
+	})
+
+	t.Run("caller options are not mutated", func(t *testing.T) {
+		opts := &ListGroupProjectsOptions{Limit: 0, IncludeSubgroups: false}
+		_ = normalizeListGroupProjectsOptions(opts)
+		assert.Equal(t, int64(0), opts.Limit, "input Limit must stay untouched")
+		assert.False(t, opts.IncludeSubgroups)
+	})
+}
+
+// TestBuildListGroupProjectsOptions verifies the mapping onto GitLab API options.
+func TestBuildListGroupProjectsOptions(t *testing.T) {
+	t.Run("archived excluded by default", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 100})
+		require.NotNil(t, got.Archived)
+		assert.False(t, *got.Archived)
+		require.NotNil(t, got.IncludeSubGroups)
+		assert.True(t, *got.IncludeSubGroups)
+		assert.Equal(t, int64(100), got.PerPage)
+		assert.Equal(t, int64(1), got.Page)
+		assert.Nil(t, got.Search)
+		assert.Nil(t, got.Topic)
+	})
+
+	t.Run("include_archived omits the archived filter", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{IncludeArchived: true, Limit: 100})
+		assert.Nil(t, got.Archived, "Archived must be omitted so GitLab returns both kinds")
+	})
+
+	t.Run("per_page never exceeds the API ceiling", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{Limit: maxProjectsTotal})
+		assert.Equal(t, int64(maxProjectsPerPage), got.PerPage)
+	})
+
+	t.Run("per_page shrinks to a small limit", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{Limit: 5})
+		assert.Equal(t, int64(5), got.PerPage)
+	})
+
+	t.Run("search and topic are passed through", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{
+			Limit: 100, Search: "api", Topic: "golang",
+		})
+		require.NotNil(t, got.Search)
+		require.NotNil(t, got.Topic)
+		assert.Equal(t, "api", *got.Search)
+		assert.Equal(t, "golang", *got.Topic)
+	})
+
+	t.Run("include_subgroups false is sent explicitly", func(t *testing.T) {
+		got := buildListGroupProjectsOptions(ListGroupProjectsOptions{Limit: 100})
+		require.NotNil(t, got.IncludeSubGroups)
+		assert.False(t, *got.IncludeSubGroups)
+	})
+}
+
+// TestConvertGitLabProject verifies the GitLab -> GroupProject mapping.
+func TestConvertGitLabProject(t *testing.T) {
+	got := convertGitLabProject(&gitlab.Project{
+		ID:                42,
+		Name:              "my-service",
+		Path:              "my-service",
+		PathWithNamespace: "myorg/team/my-service",
+		Description:       "Payment gateway",
+		Topics:            []string{"go", "api"},
+		WebURL:            "https://gitlab.com/myorg/team/my-service",
+		Archived:          true,
+	})
+
+	assert.Equal(t, GroupProject{
+		ID:          42,
+		Name:        "my-service",
+		Path:        "myorg/team/my-service",
+		Description: "Payment gateway",
+		Topics:      []string{"go", "api"},
+		WebURL:      "https://gitlab.com/myorg/team/my-service",
+		Archived:    true,
+	}, got, "Path must carry the namespaced path so it can feed the other tools")
+}
+
+// TestApp_ListGroupProjects tests the ListGroupProjects method.
+func TestApp_ListGroupProjects(t *testing.T) {
+	apiError := errors.New("gitlab client: 404 group not found")
+
+	tests := []struct {
+		name      string
+		groupPath string
+		opts      *ListGroupProjectsOptions
+		setup     func(*MockGitLabClient, *MockGroupsService)
+		want      []GroupProject
+		wantErr   bool
+		errType   error
+	}{
+		{
+			name:      "successful listing with defaults",
+			groupPath: "myorg",
+			opts:      nil,
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 100, true)).Return(
+					[]*gitlab.Project{
+						{
+							ID:                1,
+							Name:              "alpha",
+							PathWithNamespace: "myorg/alpha",
+							Description:       "First project",
+							Topics:            []string{"go"},
+							WebURL:            "https://gitlab.com/myorg/alpha",
+						},
+						{
+							ID:                2,
+							Name:              "beta",
+							PathWithNamespace: "myorg/sub/beta",
+							Description:       "Nested project",
+							Topics:            []string{"python", "api"},
+							WebURL:            "https://gitlab.com/myorg/sub/beta",
+							Archived:          true,
+						},
+					},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []GroupProject{
+				{
+					ID: 1, Name: "alpha", Path: "myorg/alpha", Description: "First project",
+					Topics: []string{"go"}, WebURL: "https://gitlab.com/myorg/alpha",
+				},
+				{
+					ID: 2, Name: "beta", Path: "myorg/sub/beta", Description: "Nested project",
+					Topics: []string{"python", "api"}, WebURL: "https://gitlab.com/myorg/sub/beta", Archived: true,
+				},
+			},
+		},
+		{
+			name:      "paginates across pages",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 250},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				// Page 1 -> NextPage 2. PerPage must stay constant across pages.
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 100, true)).Return(
+					[]*gitlab.Project{{ID: 1, Name: "a", PathWithNamespace: "myorg/a"}},
+					&gitlab.Response{NextPage: 2}, nil,
+				).Once()
+				// Page 2 -> NextPage 0, loop terminates.
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(2, 100, true)).Return(
+					[]*gitlab.Project{{ID: 2, Name: "b", PathWithNamespace: "myorg/b"}},
+					&gitlab.Response{NextPage: 0}, nil,
+				).Once()
+			},
+			want: []GroupProject{
+				{ID: 1, Name: "a", Path: "myorg/a"},
+				{ID: 2, Name: "b", Path: "myorg/b"},
+			},
+		},
+		{
+			name:      "stops paginating once the limit is reached",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 1},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				// Only one call must happen even though NextPage says more exist.
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 1, true)).Return(
+					[]*gitlab.Project{{ID: 1, Name: "a", PathWithNamespace: "myorg/a"}},
+					&gitlab.Response{NextPage: 2}, nil,
+				).Once()
+			},
+			want: []GroupProject{{ID: 1, Name: "a", Path: "myorg/a"}},
+		},
+		{
+			name:      "truncates a page larger than the limit",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 2},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 2, true)).Return(
+					[]*gitlab.Project{
+						{ID: 1, Name: "a", PathWithNamespace: "myorg/a"},
+						{ID: 2, Name: "b", PathWithNamespace: "myorg/b"},
+						{ID: 3, Name: "c", PathWithNamespace: "myorg/c"},
+					},
+					&gitlab.Response{}, nil,
+				).Once()
+			},
+			want: []GroupProject{
+				{ID: 1, Name: "a", Path: "myorg/a"},
+				{ID: 2, Name: "b", Path: "myorg/b"},
+			},
+		},
+		{
+			name:      "include_subgroups false",
+			groupPath: "myorg/team",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: false, Limit: 100},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg/team", expectedProjectOpts(1, 100, false)).Return(
+					[]*gitlab.Project{{ID: 7, Name: "direct", PathWithNamespace: "myorg/team/direct"}},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []GroupProject{{ID: 7, Name: "direct", Path: "myorg/team/direct"}},
+		},
+		{
+			name:      "include_archived sends no archived filter",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, IncludeArchived: true, Limit: 100},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				opts := expectedProjectOpts(1, 100, true)
+				opts.Archived = nil
+				groups.On("ListGroupProjects", "myorg", opts).Return(
+					[]*gitlab.Project{{ID: 9, Name: "old", PathWithNamespace: "myorg/old", Archived: true}},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []GroupProject{{ID: 9, Name: "old", Path: "myorg/old", Archived: true}},
+		},
+		{
+			name:      "search and topic filters",
+			groupPath: "myorg",
+			opts: &ListGroupProjectsOptions{
+				IncludeSubgroups: true, Limit: 100, Search: "api", Topic: "golang",
+			},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				opts := expectedProjectOpts(1, 100, true)
+				opts.Search = new("api")
+				opts.Topic = new("golang")
+				groups.On("ListGroupProjects", "myorg", opts).Return(
+					[]*gitlab.Project{{ID: 3, Name: "api-gw", PathWithNamespace: "myorg/api-gw"}},
+					&gitlab.Response{}, nil,
+				)
+			},
+			want: []GroupProject{{ID: 3, Name: "api-gw", Path: "myorg/api-gw"}},
+		},
+		{
+			name:      "empty group returns an empty slice",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 100},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 100, true)).Return(
+					[]*gitlab.Project{}, &gitlab.Response{}, nil,
+				)
+			},
+			want: []GroupProject{},
+		},
+		{
+			name:      "nil response does not loop or panic",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 100},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 100, true)).Return(
+					[]*gitlab.Project{{ID: 1, Name: "a", PathWithNamespace: "myorg/a"}},
+					(*gitlab.Response)(nil), nil,
+				).Once()
+			},
+			want: []GroupProject{{ID: 1, Name: "a", Path: "myorg/a"}},
+		},
+		{
+			name:      "empty group path",
+			groupPath: "",
+			opts:      nil,
+			setup:     nil,
+			wantErr:   true,
+			errType:   ErrGroupPathRequired,
+		},
+		{
+			name:      "API error is wrapped",
+			groupPath: "myorg",
+			opts:      &ListGroupProjectsOptions{IncludeSubgroups: true, Limit: 100},
+			setup: func(client *MockGitLabClient, groups *MockGroupsService) {
+				client.On("Groups").Return(groups)
+				groups.On("ListGroupProjects", "myorg", expectedProjectOpts(1, 100, true)).Return(
+					([]*gitlab.Project)(nil), (*gitlab.Response)(nil), apiError,
+				)
+			},
+			wantErr: true,
+			errType: apiError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockGitLabClient{}
+			mockGroups := &MockGroupsService{}
+
+			if tt.setup != nil {
+				tt.setup(mockClient, mockGroups)
+			}
+
+			app := newTestAppWithGroups(mockClient)
+
+			got, err := app.ListGroupProjects(tt.groupPath, tt.opts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					require.ErrorIs(t, err, tt.errType)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+
+			mockClient.AssertExpectations(t)
+			mockGroups.AssertExpectations(t)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type ToolCategoryFlags struct {
 	Epics           bool // Epic management tools (Premium/Ultimate tier)
 	Pipelines       bool // CI/CD pipeline tools
 	MergeRequests   bool // Merge request management tools
+	Projects        bool // Group project discovery tools
 }
 
 // Error variables for static errors.
@@ -1475,8 +1476,8 @@ func setupUpdateProjectTopicsTool(s *server.MCPServer, appInstance *app.App, deb
 	})
 }
 
-func printHelp() {
-	fmt.Printf(`GitLab MCP Server %s
+// helpText is the usage message printed by -h/--help. %s is replaced by the version.
+const helpText = `GitLab MCP Server %s
 
 A Model Context Protocol (MCP) server that provides GitLab integration tools for Claude Code.
 
@@ -1494,6 +1495,8 @@ OPTIONS:
                            Disable project metadata tools
       --no-epics           Disable epic management tools
       --no-pipelines       Disable CI/CD pipeline tools
+      --no-merge-requests  Disable merge request management tools
+      --no-projects        Disable group project discovery tools
 
 ENVIRONMENT VARIABLES:
     GITLAB_TOKEN   GitLab API personal access token (required)
@@ -1514,6 +1517,7 @@ DESCRIPTION:
     • get_project_topics       - Get the topics/tags of a project
     • update_project_topics    - Update the project topics (replaces all)
     • list_epics               - List epics for a GitLab group (Premium/Ultimate)
+    • list_group_projects      - List all projects of a group, subgroups included
 
     The server communicates via JSON-RPC 2.0 over stdin/stdout and is designed
     to be used with Claude Code's MCP architecture.
@@ -1535,7 +1539,10 @@ EXAMPLES:
     gitlab-mcp -v
 
 For more information, visit: https://github.com/sgaunet/gitlab-mcp
-`, version)
+`
+
+func printHelp() {
+	fmt.Printf(helpText, version)
 }
 
 // handleCommandLineFlags processes command line arguments and exits if necessary.
@@ -1553,6 +1560,7 @@ func handleCommandLineFlags() *ToolCategoryFlags {
 		noEpics           = flag.Bool("no-epics", false, "Disable epic management tools")
 		noPipelines       = flag.Bool("no-pipelines", false, "Disable CI/CD pipeline tools")
 		noMergeRequests   = flag.Bool("no-merge-requests", false, "Disable merge request management tools")
+		noProjects        = flag.Bool("no-projects", false, "Disable group project discovery tools")
 	)
 
 	flag.Parse()
@@ -1577,6 +1585,7 @@ func handleCommandLineFlags() *ToolCategoryFlags {
 		Epics:           !*noEpics,
 		Pipelines:       !*noPipelines,
 		MergeRequests:   !*noMergeRequests,
+		Projects:        !*noProjects,
 	}
 }
 
@@ -1854,6 +1863,12 @@ func logEnabledCategories(debugLogger *slog.Logger, flags *ToolCategoryFlags) {
 		disabled = append(disabled, "merge-requests")
 	}
 
+	if flags.Projects {
+		enabled = append(enabled, "projects")
+	} else {
+		disabled = append(disabled, "projects")
+	}
+
 	debugLogger.Info("Tool categories configuration",
 		"enabled", strings.Join(enabled, ", "),
 		"disabled", strings.Join(disabled, ", "),
@@ -1914,6 +1929,11 @@ func registerAllTools(s *server.MCPServer, appInstance *app.App, debugLogger *sl
 		setupGetMergeRequestDiffTool(s, appInstance, debugLogger)
 		setupApproveMergeRequestTool(s, appInstance, debugLogger)
 		setupAddMergeRequestNoteTool(s, appInstance, debugLogger)
+	}
+
+	// Projects category (1 tool)
+	if flags.Projects {
+		setupListGroupProjectsTool(s, appInstance, debugLogger)
 	}
 }
 

--- a/project_tools.go
+++ b/project_tools.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/sgaunet/gitlab-mcp/internal/app"
+)
+
+// marshalToolResult converts a value to a JSON tool result, reporting a formatting
+// failure as a tool error rather than a protocol error.
+func marshalToolResult(value any, debugLogger *slog.Logger, subject string) *mcp.CallToolResult {
+	jsonData, err := json.Marshal(value)
+	if err != nil {
+		debugLogger.Error("Failed to marshal response to JSON", "error", err, "subject", subject)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to format %s response", subject))
+	}
+	return mcp.NewToolResultText(string(jsonData))
+}
+
+// parseListGroupProjectsOptions extracts list group projects options from arguments.
+func parseListGroupProjectsOptions(args map[string]any) *app.ListGroupProjectsOptions {
+	opts := &app.ListGroupProjectsOptions{
+		IncludeSubgroups: true, // default: recurse through all descendant subgroups
+		Limit:            defaultLimit,
+	}
+
+	if includeSubgroups, ok := args["include_subgroups"].(bool); ok {
+		opts.IncludeSubgroups = includeSubgroups
+	}
+	if includeArchived, ok := args["include_archived"].(bool); ok {
+		opts.IncludeArchived = includeArchived
+	}
+	if search, ok := args["search"].(string); ok && search != "" {
+		opts.Search = search
+	}
+	if topic, ok := args["topic"].(string); ok && topic != "" {
+		opts.Topic = topic
+	}
+	if limitFloat, ok := args["limit"].(float64); ok {
+		opts.Limit = int64(limitFloat)
+	}
+
+	return opts
+}
+
+// setupListGroupProjectsTool creates and registers the list_group_projects tool.
+func setupListGroupProjectsTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
+	listGroupProjectsTool := mcp.NewTool("list_group_projects",
+		mcp.WithDescription("List all projects of a GitLab group, recursively including every subgroup at any depth. "+
+			"Returns each project's id, name, full namespaced path, description, topics, web URL and archived flag. "+
+			"Use the returned path with the other tools of this server (list_issues, get_project_description, ...). "+
+			"Set include_subgroups=false to list only projects owned directly by the group."),
+		mcp.WithString("group_path",
+			mcp.Required(),
+			mcp.Description("GitLab group path including all parent namespaces (e.g., 'mygroup' or "+
+				"'company/department/team'). Accepts nested group paths"),
+		),
+		mcp.WithBoolean("include_subgroups",
+			mcp.Description("Recurse into all descendant subgroups. Defaults to true for comprehensive results. "+
+				"Set to false to list only projects directly owned by the group"),
+		),
+		mcp.WithBoolean("include_archived",
+			mcp.Description("Include archived projects in the results (default: false)"),
+		),
+		mcp.WithString("search",
+			mcp.Description("Filter projects by name or path substring"),
+		),
+		mcp.WithString("topic",
+			mcp.Description("Filter projects by topic/tag"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of projects to return (default: 100, max: 1000). "+
+				"Results spanning several API pages are fetched automatically"),
+		),
+	)
+
+	s.AddTool(listGroupProjectsTool, func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := request.GetArguments()
+		debugLogger.Debug("Received list_group_projects tool request", "args", args)
+
+		// Extract group_path
+		groupPath, ok := args["group_path"].(string)
+		if !ok || groupPath == "" {
+			debugLogger.Error("group_path is not a valid string", "value", args["group_path"])
+			return mcp.NewToolResultError("group_path must be a non-empty string"), nil
+		}
+
+		opts := parseListGroupProjectsOptions(args)
+
+		debugLogger.Debug("Processing list_group_projects request", "group_path", groupPath, "opts", opts)
+
+		// Call the app method
+		projects, err := appInstance.ListGroupProjects(groupPath, opts)
+		if err != nil {
+			debugLogger.Error("Failed to list group projects", "error", err, "group_path", groupPath)
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to list group projects: %v", err)), nil
+		}
+
+		debugLogger.Info("Successfully retrieved group projects", "count", len(projects), "group_path", groupPath)
+		return marshalToolResult(projects, debugLogger, "projects"), nil
+	})
+}


### PR DESCRIPTION
- add ListGroupProjects with auto-pagination and limit clamping (100/1000)
- extend GroupsService interface, client wrapper and mock
- register list_group_projects MCP tool with filtering options
- gate the tool behind a new --no-projects category flag
- extract help text into helpText const, document --no-merge-requests
- cover pagination, filters, nil responses and API errors in tests
- document the tool in CLAUDE.md, README.md and docs/

Closes #111